### PR TITLE
✨ Feat: #29 RecordDetailBottomSheet 구현 

### DIFF
--- a/Packages/Features/Sources/Features/Map/MapView.swift
+++ b/Packages/Features/Sources/Features/Map/MapView.swift
@@ -11,7 +11,7 @@ import MapKit
 public struct MapView: View {
     
     @StateObject private var viewModel = MapViewModel()
-
+    
     @State private var moveToUserLocation = false
     
     public init() {}
@@ -20,7 +20,7 @@ public struct MapView: View {
         ZStack(alignment: .bottomTrailing) {
             MapViewRepresentable(viewModel: viewModel, moveToUserLocation: $moveToUserLocation)
                 .ignoresSafeArea()
-
+            
             // '내 위치로' 버튼
             Button {
                 moveToUserLocation = true
@@ -36,24 +36,8 @@ public struct MapView: View {
         .onAppear {
             viewModel.fetchMapObjects()
         }
-        .sheet(item: $viewModel.selectObjectDetail) { detail in
-            VStack(alignment: .leading, spacing: 16) {
-                Text(detail.title)
-                    .font(.largeTitle.bold())
-                
-                HStack {
-                    Image(systemName: "mappin.and.ellipse")
-                    Text("위도: \(detail.latitude)")
-                }
-                
-                HStack {
-                    Image(systemName: "mappin.and.ellipse")
-                    Text("경도: \(detail.longitude)")
-                }
-            }
-            .padding(30)
-            // iOS 16+ 에서 사용 가능한 시트 높이 조절
-            .presentationDetents([.height(250), .medium])
+        .sheet(item: $viewModel.selectObjectDetail) { summary in
+            RecordDetailBottomSheet(viewModel: RecordDetailViewModel(summary: summary))
         }
     }
 }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
@@ -10,33 +10,46 @@ import PhotosUI
 
 struct ImageCarouselView: View {
     @ObservedObject var viewModel: RecordDetailViewModel
-    // 현재 모달이 확장된 상태인지 여부
-    let isExpanded: Bool
-    // 최대 이미지 개수
-    let maxImageCount = 4
-    // 수정모드 여부
-    let isEditing: Bool
     
-    private let fullSize: CGFloat = 342
-    private let halfSize: CGFloat = 150
-    private let itemSpacing: CGFloat = 12
+    let isExpanded: Bool
+    let isEditing: Bool
     
     @State private var isPickerPresented = false
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
     
+    private let fullSize: CGFloat = 342
+    private let halfSize: CGFloat = 150
+    private let itemSpacing: CGFloat = 12
+    private let maxImageCount = 4
+    
+    // MARK: - Body
+    
+    var body: some View {
+        if let detail = viewModel.detail {
+            ZStack {
+                collapsedView(images: detail.images)
+                    .opacity(isExpanded ? 0 : 1)
+                
+                expandedView(images: detail.images)
+                    .opacity(isExpanded ? 1 : 0)
+            }
+            .frame(height: isExpanded ? fullSize : halfSize)
+        }
+    }
+    
     // MARK: - Collapsed & Expanded Subviews
-    private var collapsedView: some View {
-        let screenWidth = UIScreen.main.bounds.width
-        return ZStack(alignment: .bottomTrailing) {
-            if let first = viewModel.selectedImages.first {
-                Image(uiImage: first)
+    
+    private func collapsedView(images: [UIImage]) -> some View {
+        ZStack(alignment: .bottomTrailing) {
+            if let firstImage = images.first {
+                Image(uiImage: firstImage)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: halfSize, height: halfSize)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                 
-                if viewModel.selectedImages.count > 1 {
-                    Text("+\(viewModel.selectedImages.count - 1)")
+                if images.count > 1 {
+                    Text("+\(images.count - 1)")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(.white)
                         .padding(.horizontal, 10)
@@ -54,59 +67,48 @@ struct ImageCarouselView: View {
             } else {
                 Rectangle()
                     .fill(Color.gray.opacity(0.2))
-                    .frame(width: screenWidth, height: halfSize)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
             }
         }
-        .frame(width: screenWidth, height: halfSize)
+        .frame(maxWidth: .infinity)
+        .frame(height: halfSize)
     }
     
-    private var expandedView: some View {
-        let screenWidth = UIScreen.main.bounds.width
-        let horizontalPadding = (screenWidth - fullSize) / 2
-        return ScrollView(.horizontal, showsIndicators: false) {
+    private func expandedView(images: [UIImage]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: itemSpacing) {
-                ForEach(viewModel.selectedImages, id: \.self) { image in
+                ForEach(images, id: \.self) { image in
                     ImageItemView(
                         image: image,
                         size: fullSize,
                         isEditing: isEditing
-                    ) {
+                    ) { withAnimation {
                         viewModel.deleteImage(image)
                     }
+                    }
                 }
-                if isEditing && viewModel.selectedImages.count < maxImageCount {
+                
+                if isEditing && images.count < maxImageCount {
                     AddPhotoButton(size: fullSize) {
                         isPickerPresented = true
                     }
                 }
             }
-            .padding(.horizontal, horizontalPadding)
+            .padding(.horizontal, (UIScreen.main.bounds.width - fullSize) / 2)
             .scrollTargetLayout()
         }
         .scrollTargetBehavior(.viewAligned)
-        .frame(width: screenWidth, height: fullSize)
+        .frame(height: fullSize)
         .photosPicker(
             isPresented: $isPickerPresented,
             selection: $selectedPhotoItems,
-            maxSelectionCount: maxImageCount - viewModel.selectedImages.count,
+            maxSelectionCount: maxImageCount - images.count,
             matching: .images
         )
-        .onChange(of: selectedPhotoItems) {
-            viewModel.addImages(from: selectedPhotoItems)
+        .onChange(of: selectedPhotoItems) { _, newItems in
+            viewModel.addImages(from: newItems)
             selectedPhotoItems.removeAll()
         }
-    }
-    
-    var body: some View {
-        ZStack {
-            collapsedView
-                .opacity(isExpanded ? 0 : 1)
-            expandedView
-                .opacity(isExpanded ? 1 : 0)
-        }
-        .frame(height: isExpanded ? fullSize : halfSize)
-        .animation(nil, value: isExpanded)
     }
 }
 
@@ -126,9 +128,7 @@ struct ImageItemView: View {
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .overlay(alignment: .topTrailing) {
                 if isEditing {
-                    Button {
-                        deleteAction()
-                    } label: {
+                    Button(action: deleteAction) {
                         Image(systemName: "xmark.circle.fill")
                             .symbolRenderingMode(.palette)
                             .foregroundStyle(.white, .black.opacity(0.6))

--- a/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
@@ -12,7 +12,10 @@ struct ImageCarouselView: View {
     @ObservedObject var viewModel: RecordDetailViewModel
     // 현재 모달이 확장된 상태인지 여부
     let isExpanded: Bool
+    // 최대 이미지 개수
     let maxImageCount = 4
+    // 수정모드 여부
+    let isEditing: Bool
     
     private let fullSize: CGFloat = 342
     private let halfSize: CGFloat = 150
@@ -64,11 +67,15 @@ struct ImageCarouselView: View {
         return ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: itemSpacing) {
                 ForEach(viewModel.selectedImages, id: \.self) { image in
-                    ImageItemView(image: image, size: fullSize) {
+                    ImageItemView(
+                        image: image,
+                        size: fullSize,
+                        isEditing: isEditing
+                    ) {
                         viewModel.deleteImage(image)
                     }
                 }
-                if viewModel.selectedImages.count < maxImageCount {
+                if isEditing && viewModel.selectedImages.count < maxImageCount {
                     AddPhotoButton(size: fullSize) {
                         isPickerPresented = true
                     }
@@ -108,6 +115,7 @@ struct ImageCarouselView: View {
 struct ImageItemView: View {
     let image: UIImage
     let size: CGFloat
+    let isEditing: Bool
     let deleteAction: () -> Void
     
     var body: some View {
@@ -117,18 +125,20 @@ struct ImageItemView: View {
             .frame(width: size, height: size)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .overlay(alignment: .topTrailing) {
-                Button {
-                    deleteAction()
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(.white, .black.opacity(0.6))
-                        .font(.title2)
-                        .padding(12)
-                        .contentShape(Rectangle())
+                if isEditing {
+                    Button {
+                        deleteAction()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, .black.opacity(0.6))
+                            .font(.title2)
+                            .padding(12)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(8)
                 }
-                .buttonStyle(.plain)
-                .padding(8)
             }
     }
 }
@@ -153,7 +163,7 @@ struct AddPhotoButton: View {
 }
 
 #Preview {
-    ImageCarouselView(viewModel: RecordDetailViewModel(), isExpanded: true)
+    ImageCarouselView(viewModel: RecordDetailViewModel(), isExpanded: true, isEditing: true)
 }
 
 

--- a/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
@@ -1,0 +1,160 @@
+//
+//  ImageCarouselView.swift
+//  Features
+//
+//  Created by Henry on 7/19/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct ImageCarouselView: View {
+    @ObservedObject var viewModel: RecordDetailViewModel
+    // 현재 모달이 확장된 상태인지 여부
+    let isExpanded: Bool
+    let maxImageCount = 4
+    
+    private let fullSize: CGFloat = 342
+    private let halfSize: CGFloat = 150
+    private let itemSpacing: CGFloat = 12
+    
+    @State private var isPickerPresented = false
+    @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    
+    // MARK: - Collapsed & Expanded Subviews
+    private var collapsedView: some View {
+        let screenWidth = UIScreen.main.bounds.width
+        return ZStack(alignment: .bottomTrailing) {
+            if let first = viewModel.selectedImages.first {
+                Image(uiImage: first)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: halfSize, height: halfSize)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                
+                if viewModel.selectedImages.count > 1 {
+                    Text("+\(viewModel.selectedImages.count - 1)")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background {
+                            Capsule()
+                                .fill(.ultraThinMaterial)
+                                .overlay(
+                                    Capsule().stroke(Color.white.opacity(0.3), lineWidth: 0.5)
+                                )
+                        }
+                        .clipShape(Capsule())
+                        .padding(8)
+                }
+            } else {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.2))
+                    .frame(width: screenWidth, height: halfSize)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+        .frame(width: screenWidth, height: halfSize)
+    }
+    
+    private var expandedView: some View {
+        let screenWidth = UIScreen.main.bounds.width
+        let horizontalPadding = (screenWidth - fullSize) / 2
+        return ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: itemSpacing) {
+                ForEach(viewModel.selectedImages, id: \.self) { image in
+                    ImageItemView(image: image, size: fullSize) {
+                        viewModel.deleteImage(image)
+                    }
+                }
+                if viewModel.selectedImages.count < maxImageCount {
+                    AddPhotoButton(size: fullSize) {
+                        isPickerPresented = true
+                    }
+                }
+            }
+            .padding(.horizontal, horizontalPadding)
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .frame(width: screenWidth, height: fullSize)
+        .photosPicker(
+            isPresented: $isPickerPresented,
+            selection: $selectedPhotoItems,
+            maxSelectionCount: maxImageCount - viewModel.selectedImages.count,
+            matching: .images
+        )
+        .onChange(of: selectedPhotoItems) {
+            viewModel.addImages(from: selectedPhotoItems)
+            selectedPhotoItems.removeAll()
+        }
+    }
+    
+    var body: some View {
+        ZStack {
+            collapsedView
+                .opacity(isExpanded ? 0 : 1)
+            expandedView
+                .opacity(isExpanded ? 1 : 0)
+        }
+        .frame(height: isExpanded ? fullSize : halfSize)
+        .animation(nil, value: isExpanded)
+    }
+}
+
+// MARK: - Subviews
+
+struct ImageItemView: View {
+    let image: UIImage
+    let size: CGFloat
+    let deleteAction: () -> Void
+    
+    var body: some View {
+        Image(uiImage: image)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(alignment: .topTrailing) {
+                Button {
+                    deleteAction()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, .black.opacity(0.6))
+                        .font(.title2)
+                        .padding(12)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(8)
+            }
+    }
+}
+
+struct AddPhotoButton: View {
+    let size: CGFloat
+    let addAction: () -> Void
+    
+    var body: some View {
+        Button(action: addAction) {
+            VStack(spacing: 8) {
+                Image(systemName: "plus")
+                Text("사진 추가")
+            }
+            .font(.headline)
+            .foregroundColor(.secondary)
+            .frame(width: size, height: size)
+            .background(Color(.systemGray6))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+}
+
+#Preview {
+    ImageCarouselView(viewModel: RecordDetailViewModel(), isExpanded: true)
+}
+
+
+

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -1,3 +1,10 @@
+//
+//  RecordDetailBottomSheet.swift
+//  Features
+//
+//  Created by Henry on 7/19/25.
+//
+
 import SwiftUI
 import PhotosUI
 import Domain
@@ -5,79 +12,156 @@ import Domain
 public struct RecordDetailBottomSheet: View {
     @StateObject private var viewModel: RecordDetailViewModel
     @State private var currentDetent: PresentationDetent = .fraction(0.45)
-
+    
+    private var isExpanded: Bool {
+        currentDetent == .large
+    }
+    
     public init(viewModel: RecordDetailViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
-
+    
     public var body: some View {
-        VStack(spacing: 14) {
-        
-            VStack(spacing: 28) {
-                RecordDetailHeaderView(
-                    flowerName: viewModel.flowerName,
-                    flowerMeaning: viewModel.flowerMeaning
-                )
-                
-                RecordInfoView(
-                    location: viewModel.location,
-                    date: viewModel.date
-                )
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(spacing: 14) {
+                    
+                    VStack(spacing: 28) {
+                        RecordDetailHeaderView(
+                            flowerName: viewModel.flowerName,
+                            flowerMeaning: viewModel.flowerMeaning
+                        )
+                        
+                        RecordInfoView(
+                            title: $viewModel.title,
+                            isEditing: viewModel.isEditing,
+                            date: viewModel.date
+                        )
+                    }
+                    .padding(.horizontal, 20)
+                    
+                    ImageCarouselView(
+                        viewModel: viewModel,
+                        isExpanded: isExpanded,
+                        isEditing: viewModel.isEditing
+                    )
+                    
+                    Spacer()
+                    
+                    if isExpanded {
+                        EditButtonView(isEditing: viewModel.isEditing) {
+                            if viewModel.isEditing {
+                                viewModel.saveButtonTapped()
+                            } else {
+                                viewModel.editButtonTapped()
+                            }
+                        }
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .padding(.top, 34)
+                .frame(minHeight: geometry.size.height)
             }
-            .padding(.horizontal, 20)
-
-            ImageCarouselView(
-                viewModel: viewModel,
-                isExpanded: currentDetent == .large
-            )
-            
-            Spacer()
         }
-        .padding(.top, 34)
         .presentationDetents([.fraction(0.45), .large], selection: $currentDetent)
         .presentationDragIndicator(.visible)
-    }
-}
-
-// MARK: - Header
-
-private struct RecordDetailHeaderView: View {
-    let flowerName: String
-    let flowerMeaning: String
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Text(flowerName)
-                .font(.headline)
-                .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
-
-            Text(flowerMeaning)
-                .font(.subheadline)
-                .foregroundColor(Color(red: 0.43, green: 0.65, blue: 0.96))
+        .ignoresSafeArea(.keyboard, edges: .bottom)
+        .onChange(of: currentDetent) { _, newDetent in
+            if newDetent != .large, viewModel.isEditing {
+                viewModel.saveButtonTapped()
+            }
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity)
-        .background(Color(red: 0.9, green: 0.94, blue: 1).opacity(0.47))
-        .cornerRadius(8)
+    }
+    
+    // MARK: - Subviews
+    
+    private struct RecordDetailHeaderView: View {
+        let flowerName: String
+        let flowerMeaning: String
+        
+        var body: some View {
+            HStack(spacing: 8) {
+                Text(flowerName)
+                    .font(.headline)
+                Text(flowerMeaning)
+                    .font(.subheadline)
+                    .foregroundColor(Color(red: 0.43, green: 0.65, blue: 0.96))
+            }
+            .padding(.all, 8)
+            .frame(maxWidth: .infinity)
+            .background(Color(red: 0.9, green: 0.94, blue: 1).opacity(0.47))
+            .cornerRadius(8)
+        }
+    }
+    
+    private struct RecordInfoView: View {
+        @Binding var title: String
+        let isEditing: Bool
+        let date: String
+        
+        @FocusState private var isTitleFieldFocused: Bool
+        
+        var body: some View {
+            VStack(spacing: 4) {
+                HStack(spacing: 0) {
+                    if isEditing {
+                        TextField("", text: $title)
+                            .font(.system(size: 20, weight: .semibold))
+                            .multilineTextAlignment(.center)
+                            .focused($isTitleFieldFocused)
+                    } else {
+                        Text(title)
+                            .font(.system(size: 20, weight: .semibold))
+                    }
+                }
+                .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
+                
+                Text(date)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(Color(red: 0.57, green: 0.63, blue: 0.71))
+            }
+            .onChange(of: isEditing) { _, isNowEditing in
+                if isNowEditing {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        isTitleFieldFocused = true
+                    }
+                }
+            }
+        }
     }
 }
 
-// MARK: - Info
-
-private struct RecordInfoView: View {
-    let location: String
-    let date: String
-
+private struct EditButtonView: View {
+    let isEditing: Bool
+    let action: () -> Void
+    
     var body: some View {
-        VStack(spacing: 4) {
-            Text("\(location)에서")
-                .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
-
-            Text(date)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(Color(red: 0.57, green: 0.63, blue: 0.71))
+        Button(action: action) {
+            LabelView(isEditing: isEditing)
+        }
+        .buttonStyle(.plain)
+        .padding(.bottom)
+    }
+    
+    private struct LabelView: View {
+        let isEditing: Bool
+        
+        var body: some View {
+            let backgroundColor = isEditing
+            ? Color(red: 0.43, green: 0.65, blue: 0.96)
+            : Color(red: 0.94, green: 0.95, blue: 0.96)
+            
+            let textColor = isEditing
+            ? Color.white
+            : Color(red: 0.56, green: 0.56, blue: 0.56)
+            
+            return Text(isEditing ? "수정완료" : "수정")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(textColor)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(backgroundColor)
+                .cornerRadius(99)
         }
     }
 }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -17,6 +17,7 @@ public struct RecordDetailBottomSheet: View {
         currentDetent == .large
     }
     
+    // MapView에서 데이터 주입을 위해 사용
     public init(viewModel: RecordDetailViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
@@ -25,20 +26,7 @@ public struct RecordDetailBottomSheet: View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(spacing: 14) {
-                    
-                    VStack(spacing: 28) {
-                        RecordDetailHeaderView(
-                            flowerName: viewModel.flowerName,
-                            flowerMeaning: viewModel.flowerMeaning
-                        )
-                        
-                        RecordInfoView(
-                            title: $viewModel.title,
-                            isEditing: viewModel.isEditing,
-                            date: viewModel.date
-                        )
-                    }
-                    .padding(.horizontal, 20)
+                    topContent
                     
                     ImageCarouselView(
                         viewModel: viewModel,
@@ -48,16 +36,7 @@ public struct RecordDetailBottomSheet: View {
                     
                     Spacer()
                     
-                    if isExpanded {
-                        EditButtonView(isEditing: viewModel.isEditing) {
-                            if viewModel.isEditing {
-                                viewModel.saveButtonTapped()
-                            } else {
-                                viewModel.editButtonTapped()
-                            }
-                        }
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                    }
+                    bottomButton
                 }
                 .padding(.top, 34)
                 .frame(minHeight: geometry.size.height)
@@ -67,8 +46,63 @@ public struct RecordDetailBottomSheet: View {
         .presentationDragIndicator(.visible)
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .onChange(of: currentDetent) { _, newDetent in
-            if newDetent != .large, viewModel.isEditing {
+            guard newDetent != .large, viewModel.isEditing else { return }
                 viewModel.saveButtonTapped()
+        }
+    }
+    
+    // MARK: - Composed Subviews
+    
+    @ViewBuilder
+    private var topContent: some View {
+        if let detail = viewModel.detail {
+            VStack(spacing: 28) {
+                RecordDetailHeaderView(
+                    flowerName: detail.flowerName,
+                    flowerMeaning: detail.flowerMeaning
+                )
+                
+                RecordInfoView(
+                    title: Binding(
+                        get: { viewModel.detail?.title ?? "" },
+                        set: { viewModel.detail?.title = $0 }
+                    ),
+                    originalTitle: viewModel.detail?.title ?? "",
+                    isEditing: viewModel.isEditing,
+                    date: detail.date
+                )
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+    
+    @ViewBuilder
+    private var bottomButton: some View {
+        if isExpanded {
+            if viewModel.isEditing {
+                SaveButtonView(isDisabled: viewModel.isSaveButtonDisabled) {
+                    viewModel.saveButtonTapped()
+                    DispatchQueue.main.async {
+                        currentDetent = .fraction(0.45)
+                    }
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            } else {
+                HStack {
+                    Spacer()
+                    
+                    EditButtonView(
+                        onEdit: {
+                            viewModel.editButtonTapped()
+                        },
+                        onDelete: {
+                            viewModel.deleteButtonTapped()
+                        }
+                    )
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
     }
@@ -96,6 +130,7 @@ public struct RecordDetailBottomSheet: View {
     
     private struct RecordInfoView: View {
         @Binding var title: String
+        let originalTitle: String
         let isEditing: Bool
         let date: String
         
@@ -105,10 +140,17 @@ public struct RecordDetailBottomSheet: View {
             VStack(spacing: 4) {
                 HStack(spacing: 0) {
                     if isEditing {
-                        TextField("", text: $title)
-                            .font(.system(size: 20, weight: .semibold))
-                            .multilineTextAlignment(.center)
-                            .focused($isTitleFieldFocused)
+                        ZStack(alignment: .center) {
+                            if title.isEmpty {
+                                Text(originalTitle)
+                                    .font(.system(size: 20, weight: .semibold))
+                                    .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15).opacity(0.5))
+                            }
+                            TextField("", text: $title)
+                                .font(.system(size: 20, weight: .semibold))
+                                .multilineTextAlignment(.center)
+                                .focused($isTitleFieldFocused)
+                        }
                     } else {
                         Text(title)
                             .font(.system(size: 20, weight: .semibold))
@@ -132,37 +174,43 @@ public struct RecordDetailBottomSheet: View {
 }
 
 private struct EditButtonView: View {
-    let isEditing: Bool
-    let action: () -> Void
-    
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
     var body: some View {
-        Button(action: action) {
-            LabelView(isEditing: isEditing)
-        }
-        .buttonStyle(.plain)
-        .padding(.bottom)
-    }
-    
-    private struct LabelView: View {
-        let isEditing: Bool
-        
-        var body: some View {
-            let backgroundColor = isEditing
-            ? Color(red: 0.43, green: 0.65, blue: 0.96)
-            : Color(red: 0.94, green: 0.95, blue: 0.96)
-            
-            let textColor = isEditing
-            ? Color.white
-            : Color(red: 0.56, green: 0.56, blue: 0.56)
-            
-            return Text(isEditing ? "수정완료" : "수정")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(textColor)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(backgroundColor)
+        Menu {
+            Button("기록 수정", action: onEdit)
+            Button(role: .destructive, action: onDelete) {
+                Text("삭제")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 14, weight: .semibold))
+                .frame(width: 32, height: 32)
+                .background(Color(red: 0.45, green: 0.51, blue: 0.59).opacity(0.16))
+                .foregroundColor(Color(red: 0.45, green: 0.51, blue: 0.59))
                 .cornerRadius(99)
         }
+    }
+}
+
+private struct SaveButtonView: View {
+    let isDisabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text("수정 완료")
+                .font(.headline.bold())
+                .foregroundColor(.white)
+                .frame(height: 52)
+                .frame(maxWidth: .infinity)
+                .background(isDisabled ? Color.gray : Color(red: 0.43, green: 0.65, blue: 0.96))
+                .cornerRadius(12)
+        }
+        .disabled(isDisabled)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 20)
     }
 }
 

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import PhotosUI
+import Domain
+
+public struct RecordDetailBottomSheet: View {
+    @StateObject private var viewModel: RecordDetailViewModel
+    @State private var currentDetent: PresentationDetent = .fraction(0.45)
+
+    public init(viewModel: RecordDetailViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        VStack(spacing: 14) {
+        
+            VStack(spacing: 28) {
+                RecordDetailHeaderView(
+                    flowerName: viewModel.flowerName,
+                    flowerMeaning: viewModel.flowerMeaning
+                )
+                
+                RecordInfoView(
+                    location: viewModel.location,
+                    date: viewModel.date
+                )
+            }
+            .padding(.horizontal, 20)
+
+            ImageCarouselView(
+                viewModel: viewModel,
+                isExpanded: currentDetent == .large
+            )
+            
+            Spacer()
+        }
+        .padding(.top, 34)
+        .presentationDetents([.fraction(0.45), .large], selection: $currentDetent)
+        .presentationDragIndicator(.visible)
+    }
+}
+
+// MARK: - Header
+
+private struct RecordDetailHeaderView: View {
+    let flowerName: String
+    let flowerMeaning: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(flowerName)
+                .font(.headline)
+                .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
+
+            Text(flowerMeaning)
+                .font(.subheadline)
+                .foregroundColor(Color(red: 0.43, green: 0.65, blue: 0.96))
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(Color(red: 0.9, green: 0.94, blue: 1).opacity(0.47))
+        .cornerRadius(8)
+    }
+}
+
+// MARK: - Info
+
+private struct RecordInfoView: View {
+    let location: String
+    let date: String
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("\(location)에서")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
+
+            Text(date)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(Color(red: 0.57, green: 0.63, blue: 0.71))
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    RecordDetailBottomSheet(viewModel: RecordDetailViewModel())
+}

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  RecordDetailViewModel.swift.swift
+//  RecordDetailViewModel.swift
 //  Features
 //
 //  Created by Henry on 7/19/25.
@@ -10,53 +10,105 @@ import Combine
 import Domain
 import PhotosUI
 
+struct RecordDetailUIModel {
+    var title: String
+    var flowerName: String
+    var flowerMeaning: String
+    var location: String
+    var date: String
+    var images: [UIImage]
+}
+
 @MainActor
 public final class RecordDetailViewModel: ObservableObject {
     
     // MARK: - Published Properties
     
-    @Published var flowerName: String = ""
-    @Published var flowerMeaning: String = ""
-    @Published var location: String = ""
-    @Published var date: String = ""
-    @Published var title: String = ""
-    @Published var selectedImages: [UIImage] = []
-    
+    @Published var detail: RecordDetailUIModel?
     @Published var isEditing: Bool = false
     
-    // MARK: - Properties
-    // TODO: 나중에 실제 UseCase를 주입
-    // private let fetchDetailUseCase: FetchRecordDetailUseCase
+    // 수정 전 원본 데이터를 저장할 프로퍼티
+    private var originalDetail: RecordDetailUIModel?
+    
+    // MARK: - Computed Properties
+    
+    public var isSaveButtonDisabled: Bool {
+        guard let detail = detail, let originalDetail = originalDetail else {
+            return true
+        }
+        
+        // 사진이 하나도 없으면 비활성화
+        if detail.images.isEmpty {
+            return true
+        }
+        
+        // 원본과 현재 상태가 동일하면 (변경사항이 없으면) 비활성화
+        let isTitleChanged = detail.title != originalDetail.title
+        let areImagesChanged = detail.images != originalDetail.images
+        
+        if !isTitleChanged && !areImagesChanged {
+            return true
+        }
+        
+        return false
+    }
     
     // MARK: - Initialization
     
-    // ViewModel이 생성될 때 목업 데이터를 바로 로드합니다.
     public init() {
         fetchRecordDetails()
     }
     
     // MARK: - Methods
+    
     func fetchRecordDetails() {
-        // 지금은 UI 개발을 위해 임시 목업 데이터를 생성
-        // 추후, 실제 UseCase를 통해 서버에서 데이터를 가져오도록 변경 예정
+        // ---  UseCase를 호출하고 Entity를 매핑하는 코드로 대체 ---
         
-        // 1. 임시 텍스트 데이터 생성
-        self.flowerName = "프리지아"
-        self.flowerMeaning = "영원한 사랑"
-        self.location = "포항공과대학교"
-        self.title = "\(self.location)에서"
+        // 임시 데이터 생성
+        let location = "포항공과대학교"
+        let title = "\(location)에서"
+        let dummyPhotos = ["photo.artframe", "camera.fill", "tree.fill"]
+        let images = dummyPhotos.compactMap { UIImage(systemName: $0) }
         
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월 d일"
-        self.date = dateFormatter.string(from: Date())
         
-        let dummyPhotos = ["photo", "photo.fill", "photo.on.rectangle.angled", "photo.artframe"]
-        self.selectedImages = dummyPhotos.compactMap { UIImage(systemName: $0) }
+        let mockDetail = RecordDetailUIModel(
+            title: title,
+            flowerName: "프리지아",
+            flowerMeaning: "영원한 사랑",
+            location: location,
+            date: dateFormatter.string(from: Date()),
+            images: images
+        )
         
+        self.detail = mockDetail
     }
     
+    // MARK: - User Actions
+    
+    func editButtonTapped() {
+        originalDetail = detail
+        isEditing = true
+    }
+    
+    func saveButtonTapped() {
+        if detail?.title.isEmpty == true {
+            detail?.title = originalDetail?.title ?? ""
+        }
+        
+        // TODO: 변경된 detail 객체를 UseCase에 전달하여 저장하는 로직
+        print("저장할 제목: \(detail?.title ?? "")")
+        
+        isEditing = false
+    }
+    
+    func deleteButtonTapped() {
+        print("삭제 버튼 탭됨")
+    }
     
     // MARK: - Image Handling
+    
     func addImages(from items: [PhotosPickerItem]) {
         Task {
             var newImages: [UIImage] = []
@@ -66,48 +118,19 @@ public final class RecordDetailViewModel: ObservableObject {
                     newImages.append(image)
                 }
             }
-            
-            withAnimation {
-                selectedImages.append(contentsOf: newImages)
-            }
+            detail?.images.append(contentsOf: newImages)
         }
     }
     
     func deleteImage(_ image: UIImage) {
-        withAnimation {
-            selectedImages.removeAll { $0 == image }
-        }
-    }
-    
-    func editButtonTapped() {
-        isEditing = true
-    }
-    
-    
-    func saveButtonTapped() {
-        // TODO: 변경 내용을 저장 하는 로직 추가
-        print("저장할 제목: \(title)")
-        // isEditing이 false로 바뀌면, 현재 title 값을 저장하는 로직 추가
-        isEditing = false
+        detail?.images.removeAll { $0 == image }
     }
 }
 
 
-// 빌드를 위해 임시 RecordDetailViewModel 생성자 추가
 public extension RecordDetailViewModel {
     convenience init(summary: ObjectSummary) {
         self.init()
-        
-        self.flowerName = "프리지아"
-        self.flowerMeaning = "영원한 사랑"
-        self.location = "포항공과대학교"
-        
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy년 M월 d일"
-        self.date = dateFormatter.string(from: Date())
-        
-        // 임시 이미지
-        let dummyPhotos = ["photo", "photo.fill", "photo.on.rectangle.angled", "photo.artframe"]
-        self.selectedImages = dummyPhotos.compactMap { UIImage(systemName: $0) }
+        // TODO: summary 객체로부터 실제 데이터를 받아와 프로퍼티를 채우는 로직 구현
     }
 }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -19,7 +19,10 @@ public final class RecordDetailViewModel: ObservableObject {
     @Published var flowerMeaning: String = ""
     @Published var location: String = ""
     @Published var date: String = ""
+    @Published var title: String = ""
     @Published var selectedImages: [UIImage] = []
+    
+    @Published var isEditing: Bool = false
     
     // MARK: - Properties
     // TODO: 나중에 실제 UseCase를 주입
@@ -41,6 +44,7 @@ public final class RecordDetailViewModel: ObservableObject {
         self.flowerName = "프리지아"
         self.flowerMeaning = "영원한 사랑"
         self.location = "포항공과대학교"
+        self.title = "\(self.location)에서"
         
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월 d일"
@@ -76,8 +80,15 @@ public final class RecordDetailViewModel: ObservableObject {
     }
     
     func editButtonTapped() {
-        print("수정 버튼 탭됨")
-        // TODO: 수정 모드로 전환하는 로직 구현
+        isEditing = true
+    }
+    
+    
+    func saveButtonTapped() {
+        // TODO: 변경 내용을 저장 하는 로직 추가
+        print("저장할 제목: \(title)")
+        // isEditing이 false로 바뀌면, 현재 title 값을 저장하는 로직 추가
+        isEditing = false
     }
 }
 

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -1,0 +1,102 @@
+//
+//  RecordDetailViewModel.swift.swift
+//  Features
+//
+//  Created by Henry on 7/19/25.
+//
+
+import SwiftUI
+import Combine
+import Domain
+import PhotosUI
+
+@MainActor
+public final class RecordDetailViewModel: ObservableObject {
+    
+    // MARK: - Published Properties
+    
+    @Published var flowerName: String = ""
+    @Published var flowerMeaning: String = ""
+    @Published var location: String = ""
+    @Published var date: String = ""
+    @Published var selectedImages: [UIImage] = []
+    
+    // MARK: - Properties
+    // TODO: 나중에 실제 UseCase를 주입
+    // private let fetchDetailUseCase: FetchRecordDetailUseCase
+    
+    // MARK: - Initialization
+    
+    // ViewModel이 생성될 때 목업 데이터를 바로 로드합니다.
+    public init() {
+        fetchRecordDetails()
+    }
+    
+    // MARK: - Methods
+    func fetchRecordDetails() {
+        // 지금은 UI 개발을 위해 임시 목업 데이터를 생성
+        // 추후, 실제 UseCase를 통해 서버에서 데이터를 가져오도록 변경 예정
+        
+        // 1. 임시 텍스트 데이터 생성
+        self.flowerName = "프리지아"
+        self.flowerMeaning = "영원한 사랑"
+        self.location = "포항공과대학교"
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy년 M월 d일"
+        self.date = dateFormatter.string(from: Date())
+        
+        let dummyPhotos = ["photo", "photo.fill", "photo.on.rectangle.angled", "photo.artframe"]
+        self.selectedImages = dummyPhotos.compactMap { UIImage(systemName: $0) }
+        
+    }
+    
+    
+    // MARK: - Image Handling
+    func addImages(from items: [PhotosPickerItem]) {
+        Task {
+            var newImages: [UIImage] = []
+            for item in items {
+                if let data = try? await item.loadTransferable(type: Data.self),
+                   let image = UIImage(data: data) {
+                    newImages.append(image)
+                }
+            }
+            
+            withAnimation {
+                selectedImages.append(contentsOf: newImages)
+            }
+        }
+    }
+    
+    func deleteImage(_ image: UIImage) {
+        withAnimation {
+            selectedImages.removeAll { $0 == image }
+        }
+    }
+    
+    func editButtonTapped() {
+        print("수정 버튼 탭됨")
+        // TODO: 수정 모드로 전환하는 로직 구현
+    }
+}
+
+
+// 빌드를 위해 임시 RecordDetailViewModel 생성자 추가
+public extension RecordDetailViewModel {
+    convenience init(summary: ObjectSummary) {
+        self.init()
+        
+        self.flowerName = "프리지아"
+        self.flowerMeaning = "영원한 사랑"
+        self.location = "포항공과대학교"
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy년 M월 d일"
+        self.date = dateFormatter.string(from: Date())
+        
+        // 임시 이미지
+        let dummyPhotos = ["photo", "photo.fill", "photo.on.rectangle.angled", "photo.artframe"]
+        self.selectedImages = dummyPhotos.compactMap { UIImage(systemName: $0) }
+    }
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #29 
- Closes #36 
---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. RecordDetailBottomSheet 기본 구조 구현
     - 하프 모달 형태의 RecordDetailBottomSheet 레이아웃 구성
     - 제목, 날짜, 사진, 꽃 이름/꽃말 영역 기본 UI 구현
     - PresentationDetent에 따른 sheet 크기 조정
  
2. 제목 입력 및 편집 UX 개선
     - 제목 수정 버튼 및 편집 모드 추가
     - 키보드 팝업 시 레이아웃 밀림 문제 해결 (ScrollView + Geometry 적용)
     - 입력 중 모달 닫을 경우 자동 저장 처리

3. Menu 구성에 따른 버튼 수정
     - 피그마내에 있는 menu식 버튼으로 변경
     - 수정 완료 버튼 UI 반영
   
4. RecordDetailViewModel 구조 개선
     - 향후 UseCase에서 Entity Mapper가 쉽게 이루어지도록 데이터 구조체로 묶음

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="250" alt="IMG_0001" src="https://github.com/user-attachments/assets/f8097529-0119-4db5-8459-22421c2cc795" />
<img width="250" alt="IMG_0004" src="https://github.com/user-attachments/assets/7117601f-31a6-435d-9417-16b6f2b2a1c8" />
<img width="250" alt="IMG_0005" src="https://github.com/user-attachments/assets/22d4612f-d0b3-400a-b684-de5097120b5a" />
<img width="250" alt="IMG_0006" src="https://github.com/user-attachments/assets/14151c95-ab4e-43cf-a93a-298d57677dee" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- issue #30 은 구현이 안됐습니다. 디자인 어딨죠.. 
- 나중에 Data 끌어올 때가 좀 걱정되네요. 나름 고려한다고 하긴 했는데, 코드가 생각보다 복잡해져서

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- "RecordViewModel.swift" 로직 처리 방식