### PR TITLE
✨ Feat: #9  MyRecordBottomSheet 기능 및 BottomSheet 개선

### DIFF
--- a/Packages/Features/Sources/Features/Main/MainView.swift
+++ b/Packages/Features/Sources/Features/Main/MainView.swift
@@ -10,63 +10,85 @@ struct MainView: View {
     @State private var previousLocation: CLLocation? = nil
     let updateThresholdMeters = 20.0
     
-    @State private var isBottomSheetPresented = true
-    @State private var selectedDetent: PresentationDetent = .fraction(0.2)
+    @State private var sheetPosition: SheetPosition = .half
+    @GestureState private var dragOffset: CGSize = .zero
+    
+    @State private var isFullScreen = false
     
     var body: some View {
-        VStack(spacing: 16) {
-            Text("현재 위치: \(locationManager.currentAddress)")
-                .font(.headline)
-                .padding()
-            
-            if viewModel.isLoading {
-                ProgressView()
-            } else if !viewModel.motes.isEmpty {
-                Text("주변에 과거에 기록한 \(viewModel.motes.count) 모트가 있어요")
-                    .font(.subheadline)
-                    .padding()
-            }
-            
-            Button("AR 보기") {
-                nav.push(.arCamera)
-            }
-            
-            Button("디자인 시스템 예제 보기") {
-                nav.push(.designSystemExample)
-            }
-            
-            
-            Spacer()
-        }
-        .sheet(isPresented: $isBottomSheetPresented) {
-            MyRecordBottomSheet(selectedDetent: $selectedDetent)
-                .environmentObject(locationManager)
-                .presentationDetents(
-                    [.fraction(0.2), .fraction(1.0)],
-                    selection: $selectedDetent
-                )
-                .presentationDragIndicator(
-                    selectedDetent == .fraction(1.0) ? .hidden : .visible
-                )
-                .interactiveDismissDisabled(true)
-        }
-        .onReceive(locationManager.$currentLocation.compactMap { $0 }) { location in
-            if let prev = previousLocation {
-                let distance = location.distance(from: prev)
-                if distance < updateThresholdMeters {
-                    print("이동 거리가 작아서 업데이트 안 함: \(distance) m")
-                    return
+            ZStack(alignment: .bottom) {
+                Color.white.ignoresSafeArea()
+                
+                VStack(spacing: 16) {
+                    Text("현재 위치: \(locationManager.currentAddress)")
+                        .font(.headline)
+                        .padding()
+                    
+                    if viewModel.isLoading {
+                        ProgressView()
+                    } else if !viewModel.motes.isEmpty {
+                        Text("주변에 과거에 기록한 \(viewModel.motes.count) 모트가 있어요")
+                            .font(.subheadline)
+                            .padding()
+                    }
+                    
+                    Button("AR 보기") {
+                        nav.push(.arCamera)
+                    }
+                    
+                    Button("디자인 시스템 예제 보기") {
+                        nav.push(.designSystemExample)
+                    }
+                    
+                    Spacer()
                 }
+                
+                // Bottom Sheet
+                MyRecordBottomSheet(selectedPosition: $sheetPosition, locationManager: locationManager)
+                    .offset(y: sheetPosition.yOffset + dragOffset.height)
+                    .animation(.easeInOut, value: sheetPosition)
+                    .gesture(
+                        DragGesture()
+                            .updating($dragOffset) { value, state, _ in
+                                state = value.translation
+                            }
+                            .onEnded { value in
+                                if value.translation.height < -100 {
+                                    // 충분히 올렸을 때 fullScreenCover 띄우고 bottom sheet 숨김
+                                    isFullScreen = true
+                                    sheetPosition = .half // 초기화
+                                } else if value.translation.height > 100 {
+                                    sheetPosition = .half
+                                }
+                            }
+                    )
+            }
+            .onReceive(locationManager.$currentLocation.compactMap { $0 }) { location in
+                if let prev = previousLocation {
+                    let distance = location.distance(from: prev)
+                    if distance < updateThresholdMeters {
+                        return
+                    }
+                }
+                previousLocation = location
+                
+                let center = Location(
+                    latitude: location.coordinate.latitude,
+                    longitude: location.coordinate.longitude
+                )
+                viewModel.loadNearbyMotesMock(center: center, radius: 1000)
+            }
+            .fullScreenCover(isPresented: $isFullScreen) {
+                FullScreenModalView(isPresented: $isFullScreen, locationManager: locationManager)
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity,
+                                       maxHeight: .infinity)
+                                .background(Color.blue)
+                                .ignoresSafeArea(edges: .all)
+
+                    
             }
             
-            previousLocation = location
-            
-            let center = Location(
-                latitude: location.coordinate.latitude,
-                longitude: location.coordinate.longitude
-            )
-            print("현재 위치:", location.coordinate.latitude, location.coordinate.longitude)
-            viewModel.loadNearbyMotesMock(center: center, radius: 10000)
         }
     }
-}
+

--- a/Packages/Features/Sources/Features/Main/MainView.swift
+++ b/Packages/Features/Sources/Features/Main/MainView.swift
@@ -1,9 +1,3 @@
-//
-//  MainView.swift
-//  Features
-//
-//  Created by eunsong on 7/15/25.
-//
 import SwiftUI
 import CoreLocation
 import DesignSystem
@@ -14,62 +8,49 @@ struct MainView: View {
     @StateObject private var viewModel = MainViewModel()
     
     @State private var previousLocation: CLLocation? = nil
-    let updateThresholdMeters = 20.0  // 20m 이상 이동했을 때만 업데이트
+    let updateThresholdMeters = 20.0
     
-    // 👇 bottom sheet 제어용
-    @State private var sheetPosition: SheetPosition = .half
-    @GestureState private var dragOffset: CGSize = .zero
+    @State private var isBottomSheetPresented = true
+    @State private var selectedDetent: PresentationDetent = .fraction(0.2)
     
     var body: some View {
-        ZStack {
-            VStack(spacing: 16) {
-                Text("현재 위치: \(locationManager.currentAddress)")
-                    .font(.headline)
+        VStack(spacing: 16) {
+            Text("현재 위치: \(locationManager.currentAddress)")
+                .font(.headline)
+                .padding()
+            
+            if viewModel.isLoading {
+                ProgressView()
+            } else if !viewModel.motes.isEmpty {
+                Text("주변에 과거에 기록한 \(viewModel.motes.count) 모트가 있어요")
+                    .font(.subheadline)
                     .padding()
-                
-                if viewModel.isLoading {
-                    ProgressView()
-                } else if !viewModel.motes.isEmpty {
-                    Text("주변에 과거에 기록한 \(viewModel.motes.count) 모트가 있어요")
-                        .font(.subheadline)
-                        .padding()
-                }
-
-                Button("AR 보기") {
-                    nav.push(.arCamera)
-                }
-                
-                Button("디자인 시스템 예제 보기") {
-                    nav.push(.designSystemExample)
-                }
-                
-                Spacer()
             }
             
-            // 👇 Bottom Sheet
-            MyRecordBottomSheet(sheetPosition: $sheetPosition)
-                .offset(y: sheetPosition.yOffset + dragOffset.height)
-                .animation(.easeInOut, value: sheetPosition)
-                .gesture(
-                    sheetPosition == .full
-                    ? nil
-                    :  // full 상태에서는 드래그 gesture 제거
-                    DragGesture()
-                        .updating($dragOffset) { value, state, _ in
-                            state = value.translation
-                        }
-                        .onEnded { value in
-                            if value.translation.height < -100 {
-                                sheetPosition = .full
-                            } else if value.translation.height > 100 {
-                                sheetPosition = .half
-                            }
-                        }
-                )
+            Button("AR 보기") {
+                nav.push(.arCamera)
+            }
             
+            Button("디자인 시스템 예제 보기") {
+                nav.push(.designSystemExample)
+            }
+            
+            
+            Spacer()
         }
-        .onReceive(locationManager.$currentLocation.compactMap { $0 }) {
-            location in
+        .sheet(isPresented: $isBottomSheetPresented) {
+            MyRecordBottomSheet(selectedDetent: $selectedDetent)
+                .environmentObject(locationManager)
+                .presentationDetents(
+                    [.fraction(0.2), .fraction(1.0)],
+                    selection: $selectedDetent
+                )
+                .presentationDragIndicator(
+                    selectedDetent == .fraction(1.0) ? .hidden : .visible
+                )
+                .interactiveDismissDisabled(true)
+        }
+        .onReceive(locationManager.$currentLocation.compactMap { $0 }) { location in
             if let prev = previousLocation {
                 let distance = location.distance(from: prev)
                 if distance < updateThresholdMeters {
@@ -84,11 +65,7 @@ struct MainView: View {
                 latitude: location.coordinate.latitude,
                 longitude: location.coordinate.longitude
             )
-            print(
-                "현재 위치:",
-                location.coordinate.latitude,
-                location.coordinate.longitude
-            )
+            print("현재 위치:", location.coordinate.latitude, location.coordinate.longitude)
             viewModel.loadNearbyMotesMock(center: center, radius: 10000)
         }
     }

--- a/Packages/Features/Sources/Features/Main/MockDataProvider.swift
+++ b/Packages/Features/Sources/Features/Main/MockDataProvider.swift
@@ -18,7 +18,7 @@ struct MockDataProvider {
             thumbnail: "rose_thumb.png",
             objetImage: "rose_object.png"
         )
-        
+
         let flower2 = EmotionObject(
             name: "해바라기",
             floriography: "희망",
@@ -26,32 +26,96 @@ struct MockDataProvider {
             thumbnail: "sunflower_thumb.png",
             objetImage: "sunflower_object.png"
         )
-        
-        let object1 = Mote(
-            userId: UUID(),
-            title: "첫 번째 기록",
-            images: ["img1.jpg", "img2.jpg"],
-            createdAt: Date(),
-            latitude: 36.0427,          // 포항시 양덕동 대략 위도
-            longitude: 129.3589,        // 포항시 양덕동 대략 경도
-            address: "경상북도 포항시 북구 양덕동 1234-5 스타벅스",
-            flower: flower1,
-            isPublic: true
+
+        let flower3 = EmotionObject(
+            name: "백합",
+            floriography: "순수",
+            emotionType: .love,
+            thumbnail: "lily_thumb.png",
+            objetImage: "lily_object.png"
         )
-        
-        let object2 = Mote(
-            userId: UUID(),
-            title: "두 번째 기록",
-            images: ["img3.jpg"],
-            createdAt: Date().addingTimeInterval(-86400), // 하루 전
-            latitude: 36.0425,          // 약간 근처 위도
-            longitude: 129.3591,        // 약간 근처 경도
-            address: "경상북도 포항시 북구 양덕동 1234-7 근처",
-            flower: flower2,
-            isPublic: false
+
+        let flower4 = EmotionObject(
+            name: "수국",
+            floriography: "변화",
+            emotionType: .sadness,
+            thumbnail: "hydrangea_thumb.png",
+            objetImage: "hydrangea_object.png"
         )
-        
-        
-        return [object1, object2]
+
+        let baseDate = Date()
+
+        return [
+            // 기존 포항 북구 양덕동
+            Mote(
+                userId: UUID(),
+                title: "첫 번째 기록",
+                images: ["img1.jpg", "img2.jpg"],
+                createdAt: baseDate,
+                latitude: 36.0427,
+                longitude: 129.3589,
+                address: "경상북도 포항시 북구 양덕동 1234-5 스타벅스",
+                flower: flower1,
+                isPublic: true
+            ),
+            Mote(
+                userId: UUID(),
+                title: "두 번째 기록",
+                images: ["img3.jpg"],
+                createdAt: baseDate.addingTimeInterval(-86400),
+                latitude: 36.0425,
+                longitude: 129.3591,
+                address: "경상북도 포항시 북구 양덕동 1234-7 근처",
+                flower: flower2,
+                isPublic: false
+            ),
+
+            // 포스텍 청암로 77 근처 오브제
+            Mote(
+                userId: UUID(),
+                title: "포스텍 정문 앞 장미",
+                images: ["rose1.jpg"],
+                createdAt: baseDate.addingTimeInterval(-3600),
+                latitude: 36.0135,
+                longitude: 129.3235,
+                address: "경상북도 포항시 남구 청암로 77 포스텍 정문 앞",
+                flower: flower1,
+                isPublic: true
+            ),
+            Mote(
+                userId: UUID(),
+                title: "수국이 피어난 과학관 뒤",
+                images: ["hydrangea1.jpg"],
+                createdAt: baseDate.addingTimeInterval(-7200),
+                latitude: 36.0138,
+                longitude: 129.3242,
+                address: "경상북도 포항시 남구 청암로 77 과학관 뒤편",
+                flower: flower4,
+                isPublic: true
+            ),
+            Mote(
+                userId: UUID(),
+                title: "백합이 있는 중앙도서관 옆",
+                images: ["lily1.jpg"],
+                createdAt: baseDate.addingTimeInterval(-10800),
+                latitude: 36.0142,
+                longitude: 129.3228,
+                address: "경상북도 포항시 남구 청암로 77 중앙도서관 옆",
+                flower: flower3,
+                isPublic: false
+            ),
+            Mote(
+                userId: UUID(),
+                title: "햇살 가득한 학생회관 앞 해바라기",
+                images: ["sunflower1.jpg"],
+                createdAt: baseDate.addingTimeInterval(-14400),
+                latitude: 36.0140,
+                longitude: 129.3239,
+                address: "경상북도 포항시 남구 청암로 77 학생회관 앞",
+                flower: flower2,
+                isPublic: true
+            )
+        ]
     }
+
 }

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/FullScreenModalView.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/FullScreenModalView.swift
@@ -1,0 +1,118 @@
+//
+//  SwiftUIView.swift
+//  Features
+//
+//  Created by Woody on 7/21/25.
+//
+
+import SwiftUI
+import MapKit
+import CoreLocation
+
+
+struct FullScreenModalView: View {
+    @Binding var isPresented: Bool
+    var locationManager: LocationManager
+    @StateObject private var viewModel = MyRecordBottomSheetViewModel()
+    
+    var body: some View {
+        ZStack {
+            
+            VStack(alignment: .leading, spacing: 12) {
+                RoundedRectangle(cornerRadius: 3)
+                    .frame(width: 40, height: 5)
+                    .foregroundColor(.gray.opacity(0.4))
+                    .padding(.top, 8)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                HStack {
+                    Spacer()
+                    Button {
+                        isPresented = false
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title2)
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                
+                
+                Text("내 꽃")
+                    .font(.headline)
+                
+                Button(action: {
+                    // 전체 기록 보기 이동 등
+                }) {
+                    HStack {
+                        Text("전체 기록은 \(viewModel.allMotes.count)개 있습니다.")
+                            .foregroundColor(.blue)
+                            .font(.body)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.blue)
+                    }
+                    .padding()
+                    .background(Color.blue.opacity(0.1))
+                    .cornerRadius(10)
+                }
+                
+                if !viewModel.filteredMotes.isEmpty {
+                    Text("📍 \(locationManager.currentAddress)에서 심은 꽃")
+                        .font(.headline)
+                    
+                    ScrollView {
+                        ForEach(viewModel.filteredMotes.indices, id: \.self) { index in
+                            let mote = viewModel.filteredMotes[index]
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("📒 \(mote.title)")
+                                    .font(.headline)
+                                Text("🗺️ \(mote.address)")
+                                    .font(.caption)
+                                Divider()
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+                
+                if let currentLocation = locationManager.currentLocation {
+                    let identifiableLocation = IdentifiableLocation(location: currentLocation)
+                    
+                    Map(initialPosition: .region(
+                        MKCoordinateRegion(
+                            center: identifiableLocation.coordinate,
+                            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                        )
+                    )) {
+                        Marker("내 위치", coordinate: identifiableLocation.coordinate)
+                            .tint(.blue)
+                    }
+                    .mapStyle(.standard)
+                    .frame(height: 200)
+                    .cornerRadius(12)
+                }
+                
+                Spacer()
+            }
+            .padding(.top,40)
+            .padding()
+            .background(Color.white.edgesIgnoringSafeArea(.all))
+            .onAppear {
+                viewModel.loadAllMotes()
+                if let location = locationManager.currentLocation {
+                    viewModel.filterMotesByLocation(currentLocation: location)
+                }
+            }
+        }
+    }
+}
+
+struct IdentifiableLocation: Identifiable {
+    let id = UUID()
+    let location: CLLocation
+    
+    var coordinate: CLLocationCoordinate2D {
+        location.coordinate
+    }
+}
+

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheet.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheet.swift
@@ -1,156 +1,44 @@
 import SwiftUI
 import CoreLocation
-import MapKit
 
 struct MyRecordBottomSheet: View {
-    @Binding var selectedDetent: PresentationDetent
+    @Binding var selectedPosition: SheetPosition
     @StateObject private var viewModel = MyRecordBottomSheetViewModel()
-    @EnvironmentObject private var locationManager: LocationManager
-
-    @State private var isShowingFullList = false  // 전체 기록 리스트 시트 상태
-
+    var locationManager: LocationManager
+    
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(spacing: 12) {
+            // Drag Indicator
+            RoundedRectangle(cornerRadius: 3)
+                .frame(width: 40, height: 5)
+                .foregroundColor(.gray.opacity(0.4))
+                .padding(.top, 8)
+                .frame(maxWidth: .infinity, alignment: .center)
+
             if viewModel.isLoading {
                 ProgressView("로딩 중...")
+                    .frame(maxWidth: .infinity, alignment: .center)
             } else if let error = viewModel.errorMessage {
                 Text("❗️오류: \(error)")
                     .foregroundColor(.red)
             } else {
-                contentView()
+                VStack {
+                    Text("내 꽃")
+                        .font(.headline)
+                    Text("🌼 총 \(viewModel.allMotes.count)개의 기록이 있어요!")
+                        .font(.title3)
+                        .bold()
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
             }
 
-            Spacer()
+            Spacer(minLength: 0)
         }
         .padding()
+        .background(Color.white)
+        .cornerRadius(16)
         .onAppear {
-            updateMotes(for: selectedDetent)
-        }
-        .onChange(of: selectedDetent) { _, newValue in
-            updateMotes(for: newValue)
-        }
-    }
-
-    @ViewBuilder
-    private func contentView() -> some View {
-        switch selectedDetent {
-        case .fraction(0.2):
-            VStack{
-                Text("내 꽃")
-                    .font(.headline)
-                Text("🌼 총 \(viewModel.allMotes.count)개의 기록이 있어요!")
-                    .font(.title3)
-                    .bold()
-            }
-            
-        case .fraction(1.0):
-            VStack(alignment: .leading, spacing: 12) {
-                // 상단에 닫기 버튼 포함 HStack
-               
-                HStack {
-                    Spacer()
-                    Button {
-                        selectedDetent = .fraction(0.2)
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.title2)
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                }
-                Text("내 꽃")
-                    .font(.headline)
-                
-                Button(action: {
-                    // MyRecordView로 진입
-                }) {
-                    HStack {
-                        Text("전체 기록은 \(viewModel.allMotes.count)개 있습니다.")
-                            .foregroundColor(.blue)
-                            .font(.body)
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .foregroundColor(.blue)
-                    }
-                    .padding()
-                    .background(Color.blue.opacity(0.1))
-                    .cornerRadius(10)
-                }
-
-                // filteredMotes가 있을 때만 표시
-                if !viewModel.filteredMotes.isEmpty {
-                    Text("📍 \(locationManager.currentAddress)에서 심은 꽃")
-                        .font(.headline)
-
-                    ScrollView {
-                        ForEach(viewModel.filteredMotes.indices, id: \.self) { index in
-                            let mote = viewModel.filteredMotes[index]
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("📒 \(mote.title)")
-                                    .font(.headline)
-                                Text("🗺️ \(mote.address)")
-                                    .font(.caption)
-                                Divider()
-                            }
-                            .padding(.vertical, 4)
-                        }
-                    }
-                }
-
-                if let currentLocation = locationManager.currentLocation {
-                    let identifiableLocation = IdentifiableLocation(location: currentLocation)
-
-                    Map(initialPosition: .region(
-                        MKCoordinateRegion(
-                            center: identifiableLocation.coordinate,
-                            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-                        )
-                    )) {
-                        Marker("내 위치", coordinate: identifiableLocation.coordinate)
-                            .tint(.blue)
-                    }
-                    .mapStyle(.standard)
-                    .frame(width: UIScreen.main.bounds.width - 32, height: 200)
-                    .cornerRadius(12)
-                }
-            }
-
-        default:
-            EmptyView()
-        }
-    }
-
-
-    private func updateMotes(for detent: PresentationDetent) {
-        switch detent {
-        case .fraction(0.2):
             viewModel.loadAllMotes()
-        case .fraction(1.0):
-            if let location = locationManager.currentLocation {
-                viewModel.loadAllMotes()
-                viewModel.filterMotesByLocation(currentLocation: location)
-            } else {
-                viewModel.errorMessage = "현재 위치 정보를 가져올 수 없습니다"
-            }
-        default:
-            break
         }
-    }
-
-    private func detentLabel(for detent: PresentationDetent) -> String {
-        switch detent {
-        case .fraction(0.2): return "Small"
-        case .fraction(1): return "Large"
-        default: return "Other"
-        }
-    }
-}
-
-struct IdentifiableLocation: Identifiable {
-    let id = UUID()
-    let location: CLLocation
-
-    var coordinate: CLLocationCoordinate2D {
-        location.coordinate
     }
 }

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheet.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheet.swift
@@ -1,56 +1,156 @@
-//
-//  SwiftUIView.swift
-//  Features
-//
-//  Created by Woody on 7/18/25.
-//
-
 import SwiftUI
+import CoreLocation
+import MapKit
 
 struct MyRecordBottomSheet: View {
-    @Binding var sheetPosition: SheetPosition  // 👈 Binding으로 변경
-    
+    @Binding var selectedDetent: PresentationDetent
+    @StateObject private var viewModel = MyRecordBottomSheetViewModel()
+    @EnvironmentObject private var locationManager: LocationManager
+
+    @State private var isShowingFullList = false  // 전체 기록 리스트 시트 상태
+
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            VStack(spacing: 8) {
-                if sheetPosition == .half {
-                    RoundedRectangle(cornerRadius: 3)
-                        .frame(width: 40, height: 5)
-                        .foregroundColor(Color.gray.opacity(0.5))
-                        .padding(.top, 8)
-                } else {
-                    // full 모드일 때 top padding 확보
-                    Spacer().frame(height: 16)
-                }
-                
-                // Bottom sheet content
-                Text("내 기록 내용 등...")
-                    .frame(maxWidth: .infinity)
-                
-                Spacer()
+        VStack(alignment: .leading, spacing: 16) {
+            if viewModel.isLoading {
+                ProgressView("로딩 중...")
+            } else if let error = viewModel.errorMessage {
+                Text("❗️오류: \(error)")
+                    .foregroundColor(.red)
+            } else {
+                contentView()
+            }
+
+            Spacer()
+        }
+        .padding()
+        .onAppear {
+            updateMotes(for: selectedDetent)
+        }
+        .onChange(of: selectedDetent) { _, newValue in
+            updateMotes(for: newValue)
+        }
+    }
+
+    @ViewBuilder
+    private func contentView() -> some View {
+        switch selectedDetent {
+        case .fraction(0.2):
+            VStack{
+                Text("내 꽃")
+                    .font(.headline)
+                Text("🌼 총 \(viewModel.allMotes.count)개의 기록이 있어요!")
+                    .font(.title3)
+                    .bold()
             }
             
-            // 👇 X 버튼 (full 상태일 때만 표시)
-            if sheetPosition == .full {
-                Button(action: {
-                    sheetPosition = .half
-                }) {
-                    Image(systemName: "xmark")
-                        .foregroundColor(.primary)
-                        .padding(12)
-                        .background(Color(.systemGray5).opacity(0.8))
-                        .clipShape(Circle())
+        case .fraction(1.0):
+            VStack(alignment: .leading, spacing: 12) {
+                // 상단에 닫기 버튼 포함 HStack
+               
+                HStack {
+                    Spacer()
+                    Button {
+                        selectedDetent = .fraction(0.2)
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title2)
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .padding(.top, 12)
-                .padding(.trailing, 16)
+                Text("내 꽃")
+                    .font(.headline)
+                
+                Button(action: {
+                    // MyRecordView로 진입
+                }) {
+                    HStack {
+                        Text("전체 기록은 \(viewModel.allMotes.count)개 있습니다.")
+                            .foregroundColor(.blue)
+                            .font(.body)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.blue)
+                    }
+                    .padding()
+                    .background(Color.blue.opacity(0.1))
+                    .cornerRadius(10)
+                }
+
+                // filteredMotes가 있을 때만 표시
+                if !viewModel.filteredMotes.isEmpty {
+                    Text("📍 \(locationManager.currentAddress)에서 심은 꽃")
+                        .font(.headline)
+
+                    ScrollView {
+                        ForEach(viewModel.filteredMotes.indices, id: \.self) { index in
+                            let mote = viewModel.filteredMotes[index]
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("📒 \(mote.title)")
+                                    .font(.headline)
+                                Text("🗺️ \(mote.address)")
+                                    .font(.caption)
+                                Divider()
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+
+                if let currentLocation = locationManager.currentLocation {
+                    let identifiableLocation = IdentifiableLocation(location: currentLocation)
+
+                    Map(initialPosition: .region(
+                        MKCoordinateRegion(
+                            center: identifiableLocation.coordinate,
+                            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+                        )
+                    )) {
+                        Marker("내 위치", coordinate: identifiableLocation.coordinate)
+                            .tint(.blue)
+                    }
+                    .mapStyle(.standard)
+                    .frame(width: UIScreen.main.bounds.width - 32, height: 200)
+                    .cornerRadius(12)
+                }
             }
+
+        default:
+            EmptyView()
         }
-        .background(.ultraThinMaterial)
-        .cornerRadius(sheetPosition == .full ? 0 : 16)
-        .shadow(radius: sheetPosition == .full ? 0 : 10)
+    }
+
+
+    private func updateMotes(for detent: PresentationDetent) {
+        switch detent {
+        case .fraction(0.2):
+            viewModel.loadAllMotes()
+        case .fraction(1.0):
+            if let location = locationManager.currentLocation {
+                viewModel.loadAllMotes()
+                viewModel.filterMotesByLocation(currentLocation: location)
+            } else {
+                viewModel.errorMessage = "현재 위치 정보를 가져올 수 없습니다"
+            }
+        default:
+            break
+        }
+    }
+
+    private func detentLabel(for detent: PresentationDetent) -> String {
+        switch detent {
+        case .fraction(0.2): return "Small"
+        case .fraction(1): return "Large"
+        default: return "Other"
+        }
     }
 }
 
+struct IdentifiableLocation: Identifiable {
+    let id = UUID()
+    let location: CLLocation
 
-
-
+    var coordinate: CLLocationCoordinate2D {
+        location.coordinate
+    }
+}

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheetViewModel.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Combine
+import CoreLocation
+import SwiftUI
+
+@MainActor
+final class MyRecordBottomSheetViewModel: ObservableObject {
+    @Published var allMotes: [Mote] = []
+    @Published var filteredMotes: [Mote] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    func loadAllMotes() {
+        isLoading = true
+        errorMessage = nil
+
+        Task {
+            self.allMotes = MockDataProvider.mockObjects()
+            self.filteredMotes = allMotes
+            isLoading = false
+        }
+    }
+
+    func filterMotesByLocation(currentLocation: CLLocation, radiusInMeters: Double = 1000) {
+        isLoading = true
+        errorMessage = nil
+
+        Task {
+            let filtered = allMotes.filter { mote in
+                let moteLocation = CLLocation(latitude: mote.latitude, longitude: mote.longitude)
+                let distance = currentLocation.distance(from: moteLocation)
+                return distance <= radiusInMeters
+            }
+
+            self.filteredMotes = filtered
+            isLoading = false
+        }
+    }
+}
+

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/MyRecordBottomSheetViewModel.swift
@@ -21,7 +21,7 @@ final class MyRecordBottomSheetViewModel: ObservableObject {
         }
     }
 
-    func filterMotesByLocation(currentLocation: CLLocation, radiusInMeters: Double = 1000) {
+    func filterMotesByLocation(currentLocation: CLLocation, radiusInMeters: Double = 5000) {
         isLoading = true
         errorMessage = nil
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
사용자에게 현재 위치 기반 기록 확인 및 전체 기록 접근 기능을 제공하고, 더 나은 시트 UX를 만들기 위함
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #34 
- Closes #35 
- Closes #37 
- Closes #38 
- Closes #67 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. **전체 기록 개수 표시**
   - `.fraction(0.2)` 상태에서 전체 기록 총 개수 노출

2. **전체 기록 보기 버튼 추가**
   - `.fraction(1.0)` 상태에서 "전체 기록은 X개 있습니다." 버튼 표시
   - 버튼 클릭 시 전체 기록 리스트로 이동

3. **현재 위치 기반 기록 필터링 기능**
   - `LocationManager` 활용하여 반경 5km 이내 기록만 필터링

4. **지도와 사용자 위치 마커 표시**
   - `.fraction(1.0)`에서 사용자의 현재 위치를 표시한 소형 지도 추가

5. **BottomSheet 개선 (.presentationDetents 적용)**
   - 드래그 제어 제거 → `presentationDetents`를 통한 명시적 전환만 허용
   - `interactiveDismissDisabled(true)` 적용
   - 닫기 버튼으로 `.fraction(1.0)` → `.fraction(0.2)` 전환 처리

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/73fcb031-fe41-4b5e-954c-34ac4258b46e" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6d4626d4-97bd-45b5-914c-8f027bd41414" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → UI 이슈를 만들어서 반영할게요
- presentationDent 꽉차는 디자인 반영은 UI 때 하도록 하겠습니다. (다시 drag 방향으로 바뀔 수 있어요)

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- 전체 recordview로 가는 것과 mapview로 이동하는 기능은 추후에 할게요~