### PR TITLE
✨ Feat: #41 RecordSaveSheetView 및 사진 선택 기능 구현

### DIFF
--- a/Packages/Features/Sources/Features/RecordComplete/RecordCompleteView.swift
+++ b/Packages/Features/Sources/Features/RecordComplete/RecordCompleteView.swift
@@ -1,7 +1,0 @@
-//
-//  RecordCompleteView.swift
-//  Features
-//
-//  Created by eunsong on 7/15/25.
-//
-

--- a/Packages/Features/Sources/Features/RecordComplete/RecordCompleteViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordComplete/RecordCompleteViewModel.swift
@@ -1,7 +1,0 @@
-//
-//  RecordCompleteViewModel.swift
-//  Features
-//
-//  Created by eunsong on 7/15/25.
-//
-

--- a/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
@@ -1,0 +1,62 @@
+//
+//  PhotoSelectionView.swift
+//  Features
+//
+//  Created by Henry on 7/22/25.
+//
+
+import SwiftUI
+import PhotosUI
+import DesignSystem
+
+import SwiftUI
+import PhotosUI
+import DesignSystem
+
+public struct PhotoSelectionView: View {
+    @ObservedObject var viewModel: RecordSaveSheetViewModel
+    
+    @State private var isPickerPresented = false
+    @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    
+    public init(viewModel: RecordSaveSheetViewModel) {
+        _viewModel = ObservedObject(wrappedValue: viewModel)
+    }
+    
+    public var body: some View {
+        VStack(spacing: 16) {
+            RecentPhotosView(viewModel: viewModel)
+            
+            photoLibraryButton
+        }
+    }
+    
+    // MARK: - Composed Subviews
+    
+    @ViewBuilder
+    private var photoLibraryButton: some View {
+        Button(action: {
+            isPickerPresented = true
+        }) {
+            HStack {
+                Image(systemName: "photo.on.rectangle.angled")
+                Text("사진 라이브러리")
+                Spacer()
+            }
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
+            .padding(.horizontal, 20)
+            .background(.clear)
+        }
+        .photosPicker(
+            isPresented: $isPickerPresented,
+            selection: $selectedPhotoItems,
+            maxSelectionCount: viewModel.maxImageCount - viewModel.selectedImages.count,
+            matching: .images
+        )
+        .onChange(of: selectedPhotoItems) { _, newItems in
+            viewModel.addImages(from: newItems)
+            selectedPhotoItems = []
+        }
+    }
+}

--- a/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
@@ -9,10 +9,6 @@ import SwiftUI
 import PhotosUI
 import DesignSystem
 
-import SwiftUI
-import PhotosUI
-import DesignSystem
-
 public struct PhotoSelectionView: View {
     @ObservedObject var viewModel: RecordSaveSheetViewModel
     
@@ -24,7 +20,7 @@ public struct PhotoSelectionView: View {
     }
     
     public var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 20) {
             RecentPhotosView(viewModel: viewModel)
             
             photoLibraryButton

--- a/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
@@ -1,0 +1,124 @@
+//
+//  RecentPhotosView.swift
+//  Features
+//
+//  Created by Henry on 7/22/25.
+//
+
+import SwiftUI
+import PhotosUI
+import DesignSystem
+
+struct RecentPhotosView: View {
+    @ObservedObject var viewModel: RecordSaveSheetViewModel
+    
+    var body: some View {
+        VStack {
+            // 현재 권한 상태에 따른 분기
+            switch viewModel.authorizationStatus {
+            case .authorized, .limited:
+                authorizedView
+            case .denied, .restricted:
+                deniedView
+            default:
+                loadingView
+            }
+        }
+        .onAppear {
+            viewModel.checkPermissionAndFetchPhotos()
+        }
+    }
+    
+    // MARK: - Composed Subviews
+    
+    // 권한이 허용되었을 때의 뷰
+    @ViewBuilder
+    private var authorizedView: some View {
+        if viewModel.recentImages.isEmpty {
+            loadingView
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(viewModel.recentImages, id: \.self) { image in
+                        PhotoItemView(
+                            image: image,
+                            isSelected: viewModel.selectedImages.contains(image),
+                            selectedIndex: viewModel.selectedImages.firstIndex(of: image)
+                        ) {
+                            viewModel.toggleImageSelection(image)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+            .frame(height: 100)
+        }
+    }
+    
+    // 권한이 거부되었을 때의 뷰
+    @ViewBuilder
+    private var deniedView: some View {
+        VStack(spacing: 8) {
+            Text("사진첩 접근 권한이 필요합니다.")
+                .font(.headline)
+            Text("설정에서 사진 접근 권한을 허용해주세요.")
+                .font(.subheadline)
+            Button("설정으로 이동") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            .padding(.top, 8)
+        }
+        .frame(height: 72)
+    }
+    
+    // 로딩 중이거나 상태를 알 수 없을 때의 뷰
+    @ViewBuilder
+    private var loadingView: some View {
+        ProgressView().frame(height: 72)
+    }
+}
+
+// MARK: - Subviews
+
+private struct PhotoItemView: View {
+    let image: UIImage
+    let isSelected: Bool
+    let selectedIndex: Int?
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 100, height: 100)
+                .clipped()
+                .overlay {
+                    if isSelected, let index = selectedIndex {
+                        SelectionOverlay(index: index)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct SelectionOverlay: View {
+    let index: Int
+    
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Color.black.opacity(0.4)
+            
+            Text("\(index + 1)")
+                .font(.caption.bold())
+                .foregroundColor(.white)
+                .frame(width: 20, height: 20)
+                .background(Circle().fill(Color(red: 0.43, green: 0.65, blue: 0.96)))
+                .padding(4)
+        }
+    }
+}
+

--- a/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
@@ -25,6 +25,7 @@ struct RecentPhotosView: View {
             }
         }
         .onAppear {
+            // 권한 상태 확인 및 사진 불러오기
             viewModel.checkPermissionAndFetchPhotos()
         }
     }

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
@@ -22,18 +22,23 @@ public struct RecordSaveSheetView: View {
         VStack(spacing: 0) {
             RecordSaveHeaderView { dismiss() }
             
-            SelectedFlowerCardView(
-                flowerName: "프리지아",
-                flowerMeaning: "영원한 사랑",
-                flowerImageName: "flower"
-            )
-            .padding(.bottom, 30)
+            if let detail = viewModel.detail {
+                SelectedFlowerCardView(
+                    flowerName: detail.name,
+                    flowerMeaning: detail.meaning,
+                    flowerImageName: detail.imageName
+                )
+                .padding(.bottom, 30)
+            }
             
             PhotoSelectionView(viewModel: viewModel)
+                .padding(.bottom, 20)
             
             SaveButtonView(isDisabled: viewModel.isSaveButtonDisabled) {
                 viewModel.saveImages()
             }
+            
+            Spacer()
         }
         .presentationDetents([.fraction(0.8), .large])
         .interactiveDismissDisabled(true)
@@ -123,7 +128,7 @@ private struct SaveButtonView: View {
                 .cornerRadius(12)
         }
         .disabled(isDisabled)
-        .padding(.top, 36)
+        .padding(.top, 30)
         .padding(.horizontal, 20)
     }
 }

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
@@ -1,0 +1,131 @@
+//
+//  RecordSaveSheetView.swift
+//  Features
+//
+//  Created by eunsong on 7/15/25.
+//
+
+import SwiftUI
+import PhotosUI
+import Domain
+import DesignSystem
+
+public struct RecordSaveSheetView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel: RecordSaveSheetViewModel
+    
+    public init(viewModel: RecordSaveSheetViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+    
+    public var body: some View {
+        VStack(spacing: 0) {
+            RecordSaveHeaderView { dismiss() }
+            
+            SelectedFlowerCardView(
+                flowerName: "프리지아",
+                flowerMeaning: "영원한 사랑",
+                flowerImageName: "flower"
+            )
+            .padding(.bottom, 30)
+            
+            PhotoSelectionView(viewModel: viewModel)
+            
+            SaveButtonView(isDisabled: viewModel.isSaveButtonDisabled) {
+                viewModel.saveImages()
+            }
+        }
+        .presentationDetents([.fraction(0.8), .large])
+        .interactiveDismissDisabled(true)
+        .presentationDragIndicator(.hidden)
+    }
+}
+
+// MARK: - Subviews
+
+private struct RecordSaveHeaderView: View {
+    let onClose: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Spacer()
+                Button(action: onClose) {
+                    ZStack {
+                        Circle()
+                            .fill(Color(red: 0.45, green: 0.51, blue: 0.59).opacity(0.16))
+                            .frame(width: 30, height: 30)
+                        
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15).opacity(0.25))
+                    }
+                    .padding(.trailing, 20)
+                }
+            }
+            
+            Text("꽃 심기 완료!")
+                .font(DesignSystem.Font.custom(size: 18, weight: .bold))
+            
+            Text("함께 기억할 사진을 저장해주세요.")
+                .font(DesignSystem.Font.custom(size: 18, weight: .bold))
+        }
+        .padding(.top, 20)
+        .padding(.bottom, 30)
+    }
+}
+
+private struct SelectedFlowerCardView: View {
+    let flowerName: String
+    let flowerMeaning: String
+    let flowerImageName: String
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 4) {
+                DesignSystemAssets.image(named: "flower_icon")
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                
+                Text(flowerName)
+                    .font(DesignSystem.Font.custom(size: 16, weight: .medium))
+            }
+            
+            Text(flowerMeaning)
+                .font(DesignSystem.Font.custom(size: 14, weight: .regular))
+                .foregroundColor(Color(red: 0.43, green: 0.65, blue: 0.96))
+            
+            DesignSystemAssets.image(named: flowerImageName)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 120, height: 120)
+        }
+        .padding(.top, 14)
+        .padding(.bottom, 30)
+        .padding(.horizontal, 45)
+        .background(Color(red: 0.94, green: 0.96, blue: 1))
+        .cornerRadius(20)
+    }
+}
+
+private struct SaveButtonView: View {
+    let isDisabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text("저장")
+                .font(.headline.bold())
+                .foregroundColor(isDisabled ? Color(red: 0.56, green: 0.56, blue: 0.56) : Color.white)
+                .frame(height: 52)
+                .frame(maxWidth: .infinity)
+                .background(isDisabled ? Color(red: 0.88, green: 0.9, blue: 0.93).opacity(0.39) : Color(red: 0.43, green: 0.65, blue: 0.96))
+                .cornerRadius(12)
+        }
+        .disabled(isDisabled)
+        .padding(.top, 36)
+        .padding(.horizontal, 20)
+    }
+}
+        
+

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -9,30 +9,69 @@ import SwiftUI
 import Combine
 import Domain
 import PhotosUI
+import Photos
+
+struct SelectedFlowerModel {
+    let id = UUID()
+    let name: String
+    let meaning: String
+    let imageName: String
+}
 
 @MainActor
 public final class RecordSaveSheetViewModel: ObservableObject {
+    
+    @Published var detail: SelectedFlowerModel?
     @Published var recentImages: [UIImage] = []
     @Published var selectedImages: [UIImage] = []
     @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
     
+    public var isSaveButtonDisabled: Bool {
+        return selectedImages.isEmpty
+    }
+    
     let maxImageCount = 4
+    
+    // MARK: - Initialization
+    
+    public init() {
+        fetchFlower()
+        checkPermissionAndFetchPhotos()
+    }
+    
+    // MARK: - User Actions
     
     func toggleImageSelection(_ image: UIImage) {
         if let index = selectedImages.firstIndex(of: image) {
-            // 이미 선택된 사진이면 배열에서 제거
             selectedImages.remove(at: index)
         } else {
-            // 새로 선택하는 사진이면, 최대 개수를 넘지 않았을 때만 배열에 추가
             if selectedImages.count < maxImageCount {
                 selectedImages.append(image)
             }
         }
     }
     
-    public var isSaveButtonDisabled: Bool {
-        return selectedImages.isEmpty
+    func saveImages() {
+        guard !selectedImages.isEmpty else { return }
+        // TODO: 선택된 사진을 저장하는 UseCase를 구현
     }
+    
+    func addImages(from items: [PhotosPickerItem]) {
+        Task {
+            var newImages: [UIImage] = []
+            for item in items {
+                if let data = try? await item.loadTransferable(type: Data.self),
+                   let uiImage = UIImage(data: data) {
+                    newImages.append(uiImage)
+                }
+            }
+            withAnimation(.spring()) {
+                selectedImages.append(contentsOf: newImages)
+            }
+        }
+    }
+    
+    // MARK: - Data Fetching
     
     func checkPermissionAndFetchPhotos() {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
@@ -55,54 +94,56 @@ public final class RecordSaveSheetViewModel: ObservableObject {
         }
     }
     
-    func saveImages() {
-        guard !selectedImages.isEmpty else { return }
-        // TODO: 선택된 이미지를 저장하는 로직을 구현 예정
-
+    private func fetchFlower() {
+        // 임시 데이터 생성
+        self.detail = SelectedFlowerModel(
+            name: "프리지아",
+            meaning: "영원한 사랑",
+            imageName: "flower"
+        )
     }
     
-    func addImages(from items: [PhotosPickerItem]) {
+    private func fetchRecentPhotos() {
         Task {
-            var newImages: [UIImage] = []
-            for item in items {
-                if let data = try? await item.loadTransferable(type: Data.self),
-                   let uiImage = UIImage(data: data) {
-                    newImages.append(uiImage)
+            let fetchOptions = PHFetchOptions()
+            fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+            fetchOptions.fetchLimit = 20
+            
+            let fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions)
+            
+            let images = await withTaskGroup(of: UIImage?.self, returning: [UIImage].self) { group in
+                var collectedImages: [UIImage] = []
+                
+                for index in 0..<fetchResult.count {
+                    let asset = fetchResult.object(at: index)
+                    group.addTask {
+                        return await self.fetchImage(for: asset, size: CGSize(width: 100, height: 100))
+                    }
                 }
+                
+                for await image in group {
+                    if let image = image {
+                        collectedImages.append(image)
+                    }
+                }
+                
+                return collectedImages
             }
-            selectedImages.append(contentsOf: newImages)
+            
+            self.recentImages = images
         }
     }
     
-    // 최근 사진을 불러오는 로직
-    private func fetchRecentPhotos() {
-        let fetchOptions = PHFetchOptions()
-        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-        fetchOptions.fetchLimit = 20
-        
-        let fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions)
+    private func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
         let imageManager = PHImageManager.default()
-        let dispatchGroup = DispatchGroup()
-        var fetchedImages: [UIImage] = []
-        
-        // 메인 스레드 블락을 방지하기 위해 비동기적으로 작업 수행
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat
         options.isSynchronous = false
         
-        fetchResult.enumerateObjects { (asset, _, _) in
-            dispatchGroup.enter()
-            let targetSize = CGSize(width: 100, height: 100)
-            imageManager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: options) { image, _ in
-                if let image = image {
-                    fetchedImages.append(image)
-                }
-                dispatchGroup.leave()
+        return await withCheckedContinuation { continuation in
+            imageManager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: options) { image, _ in
+                continuation.resume(returning: image)
             }
-        }
-        
-        dispatchGroup.notify(queue: .main) {
-            self.recentImages = fetchedImages
         }
     }
 }

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -1,0 +1,108 @@
+//
+//  RecordSaveSheetView.swift
+//  Features
+//
+//  Created by eunsong on 7/15/25.
+//
+
+import SwiftUI
+import Combine
+import Domain
+import PhotosUI
+
+@MainActor
+public final class RecordSaveSheetViewModel: ObservableObject {
+    @Published var recentImages: [UIImage] = []
+    @Published var selectedImages: [UIImage] = []
+    @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
+    
+    let maxImageCount = 4
+    
+    func toggleImageSelection(_ image: UIImage) {
+        if let index = selectedImages.firstIndex(of: image) {
+            // 이미 선택된 사진이면 배열에서 제거
+            selectedImages.remove(at: index)
+        } else {
+            // 새로 선택하는 사진이면, 최대 개수를 넘지 않았을 때만 배열에 추가
+            if selectedImages.count < maxImageCount {
+                selectedImages.append(image)
+            }
+        }
+    }
+    
+    public var isSaveButtonDisabled: Bool {
+        return selectedImages.isEmpty
+    }
+    
+    func checkPermissionAndFetchPhotos() {
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        self.authorizationStatus = status
+        
+        switch status {
+        case .authorized, .limited:
+            fetchRecentPhotos()
+        case .notDetermined:
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                DispatchQueue.main.async {
+                    self.authorizationStatus = newStatus
+                    if newStatus == .authorized {
+                        self.fetchRecentPhotos()
+                    }
+                }
+            }
+        default:
+            break
+        }
+    }
+    
+    func saveImages() {
+        guard !selectedImages.isEmpty else { return }
+        // TODO: 선택된 이미지를 저장하는 로직을 구현 예정
+
+    }
+    
+    func addImages(from items: [PhotosPickerItem]) {
+        Task {
+            var newImages: [UIImage] = []
+            for item in items {
+                if let data = try? await item.loadTransferable(type: Data.self),
+                   let uiImage = UIImage(data: data) {
+                    newImages.append(uiImage)
+                }
+            }
+            selectedImages.append(contentsOf: newImages)
+        }
+    }
+    
+    // 최근 사진을 불러오는 로직
+    private func fetchRecentPhotos() {
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        fetchOptions.fetchLimit = 20
+        
+        let fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions)
+        let imageManager = PHImageManager.default()
+        let dispatchGroup = DispatchGroup()
+        var fetchedImages: [UIImage] = []
+        
+        // 메인 스레드 블락을 방지하기 위해 비동기적으로 작업 수행
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .highQualityFormat
+        options.isSynchronous = false
+        
+        fetchResult.enumerateObjects { (asset, _, _) in
+            dispatchGroup.enter()
+            let targetSize = CGSize(width: 100, height: 100)
+            imageManager.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFill, options: options) { image, _ in
+                if let image = image {
+                    fetchedImages.append(image)
+                }
+                dispatchGroup.leave()
+            }
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            self.recentImages = fetchedImages
+        }
+    }
+}

--- a/Packages/Features/Sources/Features/RecordSave/SwiftUIView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/SwiftUIView.swift
@@ -1,0 +1,29 @@
+//
+//  SwiftUIView.swift
+//  Features
+//
+//  Created by Henry on 7/21/25.
+//
+
+import SwiftUI
+
+public struct SwiftUIView: View {
+    @State private var isShowingSave = false
+    
+    public init() { }
+
+    public var body: some View {
+        VStack {
+            Button("꽃 저장 모달 열기") {
+                isShowingSave = true
+            }
+        }
+        .sheet(isPresented: $isShowingSave) {
+            RecordSaveSheetView(viewModel: RecordSaveSheetViewModel())
+        }
+    }
+}
+
+#Preview {
+    SwiftUIView()
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #41

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- RecordSaveSheetView 레이아웃 및 상태 구성
- 사용자 앨범의 최근 사진 최대 20장 미리보기 구현
- 미리보기 썸네일에서 최대 4장까지 사진 선택 가능
- 선택된 사진이 1장 이상일 때만 저장 버튼이 활성화됨
- 저장 버튼 탭 시 임시 저장 로직 실행
- 앨범 접근 버튼 추가 (※ 앨범 진입 후 기존 선택 반영 로직은 미구현)


---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="IMG_2609" src="https://github.com/user-attachments/assets/62636939-db7c-4791-93ea-6252adc66c05" />
<img width="300" alt="IMG_2610" src="https://github.com/user-attachments/assets/c96cf50f-3b94-472d-b68b-34997c68ee19" />


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 너무 졸린 상태로 하느라, 정리는 많이 못한거 같습니다
- 원래 향후, 데이터 연결할때를 고려해서 했어야 했는데 그부분 위주로 좀 봐주시면 좋을거 같습니다
- SwiftUIView는 테스트 용으로 넣어놓은 뷰인데, 뺴고 커밋했어야 했을까요?
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식