### PR TITLE
✨ Feat: #91 사진 라이브러리 선택 결과 미리보기 반영

### DIFF
--- a/Packages/Features/Sources/Features/RecordSave/AlbumGridItemView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/AlbumGridItemView.swift
@@ -1,0 +1,59 @@
+//
+//  AlbumGridItemView.swift
+//  Features
+//
+//  Created by Henry on 7/25/25.
+//
+
+import SwiftUI
+import Photos
+
+struct AlbumGridItemView: View {
+    let asset: PHAsset
+    let isSelected: Bool
+    let selectedIndex: Int?
+    let viewModel: RecordSaveSheetViewModel
+    let cellSize: CGFloat
+
+    @State private var image: UIImage?
+
+    var body: some View {
+        ZStack {
+            if let img = image {
+                Image(uiImage: img)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Color.gray.opacity(0.3)
+            }
+        }
+        .frame(width: cellSize, height: cellSize)
+        .clipped()
+        .contentShape(Rectangle())
+        .overlay(selectionOverlay)
+        .onAppear {
+            Task {
+                // thumbnailSize를 cellSize에 맞춰 요청하여 화질 최적화
+                let thumbnailSize = CGSize(width: cellSize * UIScreen.main.scale, height: cellSize * UIScreen.main.scale)
+                self.image = await viewModel.fetchImage(for: asset, size: thumbnailSize)
+            }
+        }
+
+    }
+
+    @ViewBuilder
+    private var selectionOverlay: some View {
+        if isSelected, let idx = selectedIndex {
+            ZStack(alignment: .topTrailing) {
+                Color.black.opacity(0.4)
+
+                Text("\(idx + 1)")
+                    .font(.caption.bold())
+                    .foregroundColor(.white)
+                    .frame(width: 20, height: 20)
+                    .background(Circle().fill(Color(red: 0.43, green: 0.65, blue: 0.96)))
+                    .padding(4)
+            }
+        }
+    }
+}

--- a/Packages/Features/Sources/Features/RecordSave/CustomAlbumView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/CustomAlbumView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import Photos
+
+struct CustomAlbumView: View {
+    @ObservedObject var viewModel: RecordSaveSheetViewModel
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var showLimitAlert = false  // ← 추가
+    
+    private let columns = 3
+    private let spacing: CGFloat = 2
+    private var gridItems: [GridItem] {
+        Array(repeating: .init(.flexible(), spacing: spacing), count: columns)
+    }
+    private var cellSize: CGFloat {
+        let totalSpacing = spacing * CGFloat(columns - 1)
+        return (UIScreen.main.bounds.width - totalSpacing) / CGFloat(columns)
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            customHeader
+            
+            ScrollView {
+                if let assetsResult = viewModel.allPhotoAssetsResult {
+                    LazyVGrid(columns: gridItems, spacing: spacing) {
+                        ForEach(0..<assetsResult.count, id: \.self) { index in
+                            let asset = assetsResult.object(at: index)
+                            
+                            AlbumGridItemView(
+                                asset: asset,
+                                isSelected: viewModel.selectedAssets.contains(asset),
+                                selectedIndex: viewModel.selectedAssets.firstIndex(of: asset),
+                                viewModel: viewModel,
+                                cellSize: cellSize
+                            )
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                // 이미 선택된 건 토글
+                                if viewModel.selectedAssets.contains(asset) {
+                                    viewModel.toggleAssetSelection(asset)
+                                }
+                                // 새로 선택하려는데 4장 초과면 alert
+                                else if viewModel.selectedAssets.count >= viewModel.maxImageCount {
+                                    showLimitAlert = true
+                                }
+                                // 그 외엔 정상 선택
+                                else {
+                                    viewModel.toggleAssetSelection(asset)
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    ProgressView()
+                }
+            }
+        }
+        .onAppear {
+            viewModel.prepareForAllPhotos()
+        }
+        .alert("최대 \(viewModel.maxImageCount)장까지 기록할 수 있어요", isPresented: $showLimitAlert) {
+            Button("확인", role: .cancel) { }
+        }
+    }
+    
+    private var customHeader: some View {
+        ZStack {
+            HStack {
+                Button(action: { dismiss() }) {
+                    Image(systemName: "xmark")
+                        .font(.headline)
+                }
+                
+                Spacer()
+                
+                if !viewModel.selectedAssets.isEmpty {
+                    Button(action: {
+                        viewModel.finalizeAssetSelection()
+                        dismiss()
+                    }) {
+                        Text("\(viewModel.selectedAssets.count) 선택")
+                            .font(.subheadline.bold())
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(Color(red: 0.43, green: 0.65, blue: 0.96))
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+            .padding(.horizontal)
+            
+            Text("사진")
+                .font(.headline.bold())
+        }
+        .padding(.vertical, 10)
+        .frame(height: 56)
+        .background(Color.white)
+    }
+}

--- a/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
@@ -21,13 +21,39 @@ public struct PhotoSelectionView: View {
     
     public var body: some View {
         VStack(spacing: 20) {
-            RecentPhotosView(viewModel: viewModel)
+            if viewModel.didSelectFromLibrary {
+                selectedPhotosGrid
+            } else {
+                RecentPhotosView(viewModel: viewModel)
+            }
             
             photoLibraryButton
         }
     }
     
     // MARK: - Composed Subviews
+
+    @ViewBuilder
+    private var selectedPhotosGrid: some View {
+        GeometryReader { geo in
+            let totalImageWidth = geo.size.width - (4 * 3)
+            let photoSize = totalImageWidth / 4
+
+            HStack(spacing: 4) {
+                ForEach(viewModel.selectedImages, id: \.self) { image in
+                    SelectedPhotoView(
+                        image: image,
+                        deleteAction: {
+                            viewModel.removeSelectedImage(image)
+                        },
+                        size: photoSize
+                    )
+                }
+            }
+            .position(x: geo.size.width / 2, y: geo.size.height / 2)
+        }
+        .frame(height: 100)
+    }
     
     @ViewBuilder
     private var photoLibraryButton: some View {
@@ -41,17 +67,17 @@ public struct PhotoSelectionView: View {
             }
             .font(.system(size: 16, weight: .semibold))
             .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
-            .padding(.horizontal, 20)
             .background(.clear)
         }
         .photosPicker(
             isPresented: $isPickerPresented,
             selection: $selectedPhotoItems,
-            maxSelectionCount: viewModel.maxImageCount - viewModel.selectedImages.count,
+            maxSelectionCount: viewModel.maxImageCount,
             matching: .images
         )
         .onChange(of: selectedPhotoItems) { _, newItems in
-            viewModel.addImages(from: newItems)
+            viewModel.replaceImages(from: newItems)
+            
             selectedPhotoItems = []
         }
     }

--- a/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
@@ -48,7 +48,7 @@ public struct PhotoSelectionView: View {
                     )
                 }
             }
-            .position(x: geo.size.width / 2, y: geo.size.height / 2)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
         .frame(height: 100)
     }

--- a/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
@@ -11,9 +11,7 @@ import DesignSystem
 
 public struct PhotoSelectionView: View {
     @ObservedObject var viewModel: RecordSaveSheetViewModel
-    
-    @State private var isPickerPresented = false
-    @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    @State private var showCustomAlbum = false
     
     public init(viewModel: RecordSaveSheetViewModel) {
         _viewModel = ObservedObject(wrappedValue: viewModel)
@@ -32,13 +30,13 @@ public struct PhotoSelectionView: View {
     }
     
     // MARK: - Composed Subviews
-
+    
     @ViewBuilder
     private var selectedPhotosGrid: some View {
         GeometryReader { geo in
             let totalImageWidth = geo.size.width - (4 * 3)
             let photoSize = totalImageWidth / 4
-
+            
             HStack(spacing: 4) {
                 ForEach(viewModel.selectedImages, id: \.self) { image in
                     SelectedPhotoView(
@@ -58,7 +56,9 @@ public struct PhotoSelectionView: View {
     @ViewBuilder
     private var photoLibraryButton: some View {
         Button(action: {
-            isPickerPresented = true
+            // CustomAlbumView 띄우기 전 전체 사진 호출
+            viewModel.prepareForAllPhotos()
+            showCustomAlbum = true
         }) {
             HStack {
                 Image(systemName: "photo.on.rectangle.angled")
@@ -69,16 +69,8 @@ public struct PhotoSelectionView: View {
             .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
             .background(.clear)
         }
-        .photosPicker(
-            isPresented: $isPickerPresented,
-            selection: $selectedPhotoItems,
-            maxSelectionCount: viewModel.maxImageCount,
-            matching: .images
-        )
-        .onChange(of: selectedPhotoItems) { _, newItems in
-            viewModel.replaceImages(from: newItems)
-            
-            selectedPhotoItems = []
+        .fullScreenCover(isPresented: $showCustomAlbum) {
+            CustomAlbumView(viewModel: viewModel)
         }
     }
 }

--- a/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
@@ -50,7 +50,6 @@ struct RecentPhotosView: View {
                         }
                     }
                 }
-                .padding(.horizontal, 20)
             }
             .frame(height: 100)
         }

--- a/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
@@ -2,19 +2,19 @@
 //  RecentPhotosView.swift
 //  Features
 //
-//  Created by Henry on 7/22/25.
+//  Created by Henry on 7/25/25.
 //
 
 import SwiftUI
 import PhotosUI
 import DesignSystem
+import Photos
 
 struct RecentPhotosView: View {
     @ObservedObject var viewModel: RecordSaveSheetViewModel
     
     var body: some View {
         VStack {
-            // 현재 권한 상태에 따른 분기
             switch viewModel.authorizationStatus {
             case .authorized, .limited:
                 authorizedView
@@ -24,38 +24,42 @@ struct RecentPhotosView: View {
                 loadingView
             }
         }
-        .onAppear {
-            // 권한 상태 확인 및 사진 불러오기
-            viewModel.checkPermissionAndFetchPhotos()
-        }
     }
     
     // MARK: - Composed Subviews
     
-    // 권한이 허용되었을 때의 뷰
     @ViewBuilder
     private var authorizedView: some View {
-        if viewModel.recentImages.isEmpty {
+        if viewModel.isLoading {
             loadingView
+        } else if viewModel.recentPhotoAssets.isEmpty {
+            VStack {
+                Text("사진이 없습니다.")
+                    .font(.headline)
+                Text("카메라로 사진을 촬영하여 추억을 기록해보세요.")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+            }.frame(height: 100)
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 4) {
-                    ForEach(viewModel.recentImages, id: \.self) { image in
+                    ForEach(viewModel.recentPhotoAssets, id: \.self) { asset in
                         PhotoItemView(
-                            image: image,
-                            isSelected: viewModel.selectedImages.contains(image),
-                            selectedIndex: viewModel.selectedImages.firstIndex(of: image)
+                            asset: asset,
+                            isSelected: viewModel.selectedAssets.contains(asset),
+                            selectedIndex: viewModel.selectedAssets.firstIndex(of: asset),
+                            viewModel: viewModel
                         ) {
-                            viewModel.toggleImageSelection(image)
+                            viewModel.toggleAssetSelection(asset)
                         }
                     }
                 }
+                .padding(.horizontal)
             }
             .frame(height: 100)
         }
     }
     
-    // 권한이 거부되었을 때의 뷰
     @ViewBuilder
     private var deniedView: some View {
         VStack(spacing: 8) {
@@ -70,38 +74,52 @@ struct RecentPhotosView: View {
             }
             .padding(.top, 8)
         }
-        .frame(height: 72)
+        .frame(height: 100)
     }
     
-    // 로딩 중이거나 상태를 알 수 없을 때의 뷰
     @ViewBuilder
     private var loadingView: some View {
-        ProgressView().frame(height: 72)
+        ProgressView().frame(height: 100)
     }
 }
 
 // MARK: - Subviews
 
 private struct PhotoItemView: View {
-    let image: UIImage
+    let asset: PHAsset
     let isSelected: Bool
     let selectedIndex: Int?
+    let viewModel: RecordSaveSheetViewModel
     let action: () -> Void
     
+    @State private var image: UIImage?
+
     var body: some View {
         Button(action: action) {
-            Image(uiImage: image)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 100, height: 100)
-                .clipped()
-                .overlay {
-                    if isSelected, let index = selectedIndex {
-                        SelectionOverlay(index: index)
-                    }
+            ZStack {
+                if let image = image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    Rectangle()
+                        .fill(Color(red: 0.85, green: 0.85, blue: 0.85))
                 }
+            }
+            .frame(width: 100, height: 100)
+            .clipped()
+            .overlay {
+                if isSelected, let index = selectedIndex {
+                    SelectionOverlay(index: index)
+                }
+            }
         }
         .buttonStyle(.plain)
+        .onAppear {
+            Task {
+                self.image = await viewModel.fetchImage(for: asset, size: CGSize(width: 250, height: 250))
+            }
+        }
     }
 }
 
@@ -121,4 +139,3 @@ private struct SelectionOverlay: View {
         }
     }
 }
-

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
@@ -40,7 +40,8 @@ public struct RecordSaveSheetView: View {
             
             Spacer()
         }
-        .presentationDetents([.fraction(0.8), .large])
+        .padding(.horizontal, 20)
+        .presentationDetents([.fraction(0.8)])
         .interactiveDismissDisabled(true)
         .presentationDragIndicator(.hidden)
     }
@@ -129,7 +130,6 @@ private struct SaveButtonView: View {
         }
         .disabled(isDisabled)
         .padding(.top, 30)
-        .padding(.horizontal, 20)
     }
 }
         

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
@@ -66,7 +66,6 @@ private struct RecordSaveHeaderView: View {
                             .font(.system(size: 14, weight: .medium))
                             .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15).opacity(0.25))
                     }
-                    .padding(.trailing, 20)
                 }
             }
             

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -1,8 +1,8 @@
 //
-//  RecordSaveSheetView.swift
+//  RecordSaveSheetViewModel.swift
 //  Features
 //
-//  Created by eunsong on 7/15/25.
+//  Created by eunsong on 7/25/25.
 //
 
 import SwiftUI
@@ -21,14 +21,26 @@ struct SelectedFlowerModel {
 @MainActor
 public final class RecordSaveSheetViewModel: ObservableObject {
     
+    // MARK: - Properties
+    
     @Published var detail: SelectedFlowerModel?
-    @Published var recentImages: [UIImage] = []
+    
+    // RecentPhotosView를 위한 20개의 에셋 배열
+    @Published var recentPhotoAssets: [PHAsset] = []
+    // CustomAlbumView를 위한 전체 사진 목록
+    @Published var allPhotoAssetsResult: PHFetchResult<PHAsset>?
+    
+    @Published var selectedAssets: [PHAsset] = []
     @Published var selectedImages: [UIImage] = []
+    
     @Published var didSelectFromLibrary: Bool = false
     @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
+    @Published var isLoading = false
+    
+    private let cachingImageManager = PHCachingImageManager()
     
     public var isSaveButtonDisabled: Bool {
-        return selectedImages.isEmpty
+        return selectedAssets.isEmpty
     }
     
     let maxImageCount = 4
@@ -37,125 +49,137 @@ public final class RecordSaveSheetViewModel: ObservableObject {
     
     public init() {
         fetchFlower()
-        checkPermissionAndFetchPhotos()
+        fetchInitialRecentAssets() // 앱 시작 시 최근 에셋 20개 우선 호출
     }
     
     // MARK: - User Actions
     
-    func toggleImageSelection(_ image: UIImage) {
-        if let index = selectedImages.firstIndex(of: image) {
-            selectedImages.remove(at: index)
-        } else {
-            if selectedImages.count < maxImageCount {
-                selectedImages.append(image)
-            }
-        }
-    }
-    
-    func saveImages() {
-        guard !selectedImages.isEmpty else { return }
-        // TODO: 선택된 사진을 저장하는 UseCase를 구현
-    }
-    
-    func replaceImages(from items: [PhotosPickerItem]) {
-        
-        guard !items.isEmpty else { return }
-        
+    func finalizeAssetSelection() {
         Task {
-            var newImages: [UIImage] = []
-            for item in items.prefix(maxImageCount) {
-                if let data = try? await item.loadTransferable(type: Data.self),
-                   let uiImage = UIImage(data: data) {
-                    newImages.append(uiImage)
+            self.isLoading = true
+            var images: [UIImage] = []
+            for asset in selectedAssets {
+                if let image = await fetchImage(for: asset, size: CGSize(width: 400, height: 400)) {
+                    images.append(image)
                 }
             }
-            selectedImages = Array(newImages.prefix(maxImageCount))
+            self.selectedImages = images
             self.didSelectFromLibrary = true
+            self.isLoading = false
         }
-    }
-    
-    // MARK: - Data Fetching
-    
-    func checkPermissionAndFetchPhotos() {
-        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        self.authorizationStatus = status
-        
-        switch status {
-        case .authorized, .limited:
-            fetchRecentPhotos()
-        case .notDetermined:
-            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
-                DispatchQueue.main.async {
-                    self.authorizationStatus = newStatus
-                    if newStatus == .authorized {
-                        self.fetchRecentPhotos()
-                    }
-                }
-            }
-        default:
-            break
-        }
-    }
-    
-    private func fetchFlower() {
-        // 임시 데이터 생성
-        self.detail = SelectedFlowerModel(
-            name: "프리지아",
-            meaning: "영원한 사랑",
-            imageName: "flower"
-        )
     }
     
     func removeSelectedImage(_ image: UIImage) {
         if let index = selectedImages.firstIndex(of: image) {
             selectedImages.remove(at: index)
+            if selectedAssets.indices.contains(index) {
+                selectedAssets.remove(at: index)
+            }
         }
     }
     
-    func clearSelectedImages() {
-        selectedImages.removeAll()
+    func toggleAssetSelection(_ asset: PHAsset) {
+        if let index = selectedAssets.firstIndex(of: asset) {
+            selectedAssets.remove(at: index)
+        } else if selectedAssets.count < maxImageCount {
+            selectedAssets.append(asset)
+        }
+    }
+    
+    func saveImages() {
+        guard !selectedAssets.isEmpty else { return }
+        Task {
+            var imagesToSave: [UIImage] = []
+            for asset in selectedAssets {
+                if let image = await fetchImage(for: asset, size: PHImageManagerMaximumSize) {
+                    imagesToSave.append(image)
+                }
+            }
+            // TODO: imagesToSave 배열을 사용하여 실제 저장 UseCase에 전달
+            print("\(imagesToSave.count)개의 이미지가 저장 준비 완료")
+        }
+    }
+    
+    func clearSelectedAssets() {
+        selectedAssets.removeAll()
         didSelectFromLibrary = false
     }
     
-    private func fetchRecentPhotos() {
-        Task {
-            let fetchOptions = PHFetchOptions()
-            fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-            fetchOptions.fetchLimit = 20
-            
-            let fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions)
-            
-            let images = await withTaskGroup(of: UIImage?.self, returning: [UIImage].self) { group in
-                var collectedImages: [UIImage] = []
-                
-                for index in 0..<fetchResult.count {
-                    let asset = fetchResult.object(at: index)
-                    group.addTask {
-                        return await self.fetchImage(for: asset, size: CGSize(width: 100, height: 100))
-                    }
-                }
-                
-                for await image in group {
-                    if let image = image {
-                        collectedImages.append(image)
-                    }
-                }
-                
-                return collectedImages
+    // MARK: - Data Fetching
+    
+    private func fetchFlower() {
+        self.detail = SelectedFlowerModel(name: "프리지아", meaning: "영원한 사랑", imageName: "flower")
+    }
+    
+    /// RecentPhotosView를  위한 최근 사진 20개 우선 호출
+    func fetchInitialRecentAssets() {
+        isLoading = true
+        checkPermission { [weak self] hasPermission in
+            guard let self = self, hasPermission else {
+                DispatchQueue.main.async { self?.isLoading = false }
+                return
             }
             
-            self.recentImages = images
+            DispatchQueue.global(qos: .userInitiated).async {
+                let fetchOptions = PHFetchOptions()
+                fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+                fetchOptions.fetchLimit = 20
+                
+                let fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions)
+                var assets: [PHAsset] = []
+                fetchResult.enumerateObjects { asset, _, _ in assets.append(asset) }
+                
+                DispatchQueue.main.async {
+                    self.recentPhotoAssets = assets
+                    self.isLoading = false
+                }
+            }
         }
     }
     
-    private func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
-        let imageManager = PHImageManager.default()
+    /// CustomAlbumView를 위해 전체 사진 목록(PHFetchResult) 준비
+    func prepareForAllPhotos() {
+        guard allPhotoAssetsResult == nil else { return } // 이미 로드했다면 다시 로드하지 않음
+
+        checkPermission { [weak self] hasPermission in
+            guard let self = self, hasPermission else { return }
+
+            let opts = PHFetchOptions()
+            opts.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+            self.allPhotoAssetsResult = PHAsset.fetchAssets(with: .image, options: opts)
+        }
+    }
+    
+    private func checkPermission(completion: @escaping (Bool) -> Void) {
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        self.authorizationStatus = status
+        
+        switch status {
+        case .authorized, .limited:
+            completion(true)
+        case .notDetermined:
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                DispatchQueue.main.async {
+                    self.authorizationStatus = newStatus
+                    completion(newStatus == .authorized || newStatus == .limited)
+                }
+            }
+        default:
+            completion(false)
+        }
+    }
+
+    /// 주어진 PHAsset으로 UIImage를 비동기적으로 호출  (캐싱 적용).
+    public func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat
-        options.isSynchronous = false
+        options.isNetworkAccessAllowed = true
         
         return await withCheckedContinuation { continuation in
-            imageManager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: options) { image, _ in
+            cachingImageManager.requestImage(for: asset,
+                                         targetSize: size,
+                                         contentMode: .aspectFill,
+                                         options: options) { image, _ in
                 continuation.resume(returning: image)
             }
         }

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -24,6 +24,7 @@ public final class RecordSaveSheetViewModel: ObservableObject {
     @Published var detail: SelectedFlowerModel?
     @Published var recentImages: [UIImage] = []
     @Published var selectedImages: [UIImage] = []
+    @Published var didSelectFromLibrary: Bool = false
     @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
     
     public var isSaveButtonDisabled: Bool {
@@ -56,18 +57,20 @@ public final class RecordSaveSheetViewModel: ObservableObject {
         // TODO: 선택된 사진을 저장하는 UseCase를 구현
     }
     
-    func addImages(from items: [PhotosPickerItem]) {
+    func replaceImages(from items: [PhotosPickerItem]) {
+        
+        guard !items.isEmpty else { return }
+        
         Task {
             var newImages: [UIImage] = []
-            for item in items {
+            for item in items.prefix(maxImageCount) {
                 if let data = try? await item.loadTransferable(type: Data.self),
                    let uiImage = UIImage(data: data) {
                     newImages.append(uiImage)
                 }
             }
-            withAnimation(.spring()) {
-                selectedImages.append(contentsOf: newImages)
-            }
+            selectedImages = Array(newImages.prefix(maxImageCount))
+            self.didSelectFromLibrary = true
         }
     }
     
@@ -101,6 +104,17 @@ public final class RecordSaveSheetViewModel: ObservableObject {
             meaning: "영원한 사랑",
             imageName: "flower"
         )
+    }
+    
+    func removeSelectedImage(_ image: UIImage) {
+        if let index = selectedImages.firstIndex(of: image) {
+            selectedImages.remove(at: index)
+        }
+    }
+    
+    func clearSelectedImages() {
+        selectedImages.removeAll()
+        didSelectFromLibrary = false
     }
     
     private func fetchRecentPhotos() {

--- a/Packages/Features/Sources/Features/RecordSave/SelectedPhotoView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/SelectedPhotoView.swift
@@ -1,0 +1,32 @@
+//
+//  SelectedPhotoView.swift
+//  Features
+//
+//  Created by Henry on 7/24/25.
+//
+
+import SwiftUI
+
+public struct SelectedPhotoView: View {
+    let image: UIImage
+    let deleteAction: () -> Void
+    let size: CGFloat
+
+    public var body: some View {
+        Image(uiImage: image)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: size, height: size)
+            .clipped()
+            .overlay(alignment: .topTrailing) {
+                Button(action: deleteAction) {
+                    Image(systemName: "xmark.circle.fill")
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, .black.opacity(0.6))
+                        .font(.title3)
+                }
+                .buttonStyle(.plain)
+                .padding(4)
+            }
+    }
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #91 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 선택된 사진들은 기존 미리보기 리스트를 숨기고 최대 4장까지 표시
- 중복 선택 방지 및 기존 사진 유지 로직 포함
- 선택 후 즉시 미리보기 영역에서 확인 가능
- 
[추가 작업 내용]
- PhotosPicker 제거, 커스텀 앨범 뷰로 대체
- UIImage 기반 선택 로직 → PHAsset 기반으로 전환
- .sheet 방식을 **.fullScreenCover**로 전환하여 피그마 플로우와 일치
- 앨범 상단에 커스텀 헤더 바 추가 (닫기/확인 버튼 포함)
- 내부 상태 및 ViewModel 구조 정리
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


https://github.com/user-attachments/assets/b96e2b2f-6483-4180-bb7d-5fd488105005



---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- photsPicker 기본 기능 내에서 사용자가 선택한 사진 감지 불가 (개인정보 이슈)
-> 이를 해결하려면, 커스텀 앨범을 만들어야 한다고 함

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- 