### PR TITLE
✨ Feat: #102 RecordDetailViewModel 개선 및 MyRecordView 기능 구현

### DIFF
--- a/Packages/Features/Sources/Features/Map/MapView.swift
+++ b/Packages/Features/Sources/Features/Map/MapView.swift
@@ -37,7 +37,7 @@ public struct MapView: View {
             viewModel.fetchMapObjects()
         }
         .sheet(item: $viewModel.selectObjectDetail) { summary in
-            RecordDetailBottomSheet(viewModel: RecordDetailViewModel(summary: summary))
+            RecordDetailBottomSheet(viewModel: RecordDetailViewModel(id: summary.id))
         }
     }
 }

--- a/Packages/Features/Sources/Features/Map/MapViewRepresentable.swift
+++ b/Packages/Features/Sources/Features/Map/MapViewRepresentable.swift
@@ -2,212 +2,168 @@ import SwiftUI
 import MapKit
 
 struct MapViewRepresentable: UIViewRepresentable {
-    
     @ObservedObject var viewModel: MapViewModel
     @Binding var moveToUserLocation: Bool
-    
+
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
         mapView.delegate = context.coordinator
-        
-        // Annotation 등록
         mapView.register(MKMarkerAnnotationView.self, forAnnotationViewWithReuseIdentifier: "marker")
-        
         mapView.showsUserLocation = true
         mapView.showsCompass = true
-        
         return mapView
     }
-    
+
     func updateUIView(_ uiView: MKMapView, context: Context) {
-        updateAnnotations(from: uiView)
-        
-        if moveToUserLocation {
-            if let userLocation = uiView.userLocation.location {
-                let region = MKCoordinateRegion(
-                    center: userLocation.coordinate,
-                    span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-                )
-                uiView.setRegion(region, animated: true)
-            }
-            DispatchQueue.main.async {
-                self.moveToUserLocation = false
-            }
-        }
-        
-        if let cameraPosition = viewModel.cameraPosition {
-            let region = MKCoordinateRegion(
-                center: cameraPosition,
-                span: uiView.region.span
-            )
-            uiView.setRegion(region, animated: true)
-            DispatchQueue.main.async {
-                viewModel.cameraPosition = nil
-            }
-        }
+        updateAnnotationsIfNeeded(on: uiView)
+        moveToUserLocationIfNeeded(on: uiView)
+        moveToCameraPositionIfNeeded(on: uiView)
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
-    private func updateAnnotations(from mapView: MKMapView) {
-        let existingAnnotations = mapView.annotations
-            .compactMap { $0 as? ObjectAnnotation }
-            .reduce(into: [UUID: ObjectAnnotation]()) { dict, annotation in
-                dict[annotation.id] = annotation
-            }
-        
+
+    private func updateAnnotationsIfNeeded(on mapView: MKMapView) {
+        let existing = getExistingAnnotations(from: mapView)
+        let (toAdd, toRemove) = calculateAnnotationDifferences(existing: existing)
+        applyAnnotationChanges(to: mapView, add: toAdd, remove: toRemove)
+    }
+
+    private func moveToUserLocationIfNeeded(on mapView: MKMapView) {
+        guard moveToUserLocation, let userLocation = mapView.userLocation.location else { return }
+        let region = MKCoordinateRegion(center: userLocation.coordinate, span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
+        mapView.setRegion(region, animated: true)
+        DispatchQueue.main.async { self.moveToUserLocation = false }
+    }
+
+    private func moveToCameraPositionIfNeeded(on mapView: MKMapView) {
+        guard let position = viewModel.cameraPosition else { return }
+        let region = MKCoordinateRegion(center: position, span: mapView.region.span)
+        mapView.setRegion(region, animated: true)
+        DispatchQueue.main.async { viewModel.cameraPosition = nil }
+    }
+
+    private func getExistingAnnotations(from mapView: MKMapView) -> [UUID: ObjectAnnotation] {
+        mapView.annotations.compactMap { $0 as? ObjectAnnotation }.reduce(into: [UUID: ObjectAnnotation]()) { $0[$1.id] = $1 }
+    }
+
+    private func calculateAnnotationDifferences(existing: [UUID: ObjectAnnotation]) -> ([ObjectAnnotation], [MKAnnotation]) {
         var toAdd: [ObjectAnnotation] = []
         var toRemove: [MKAnnotation] = []
-        
+
         for summary in viewModel.objectSummaries {
-            let new = ObjectAnnotation(
-                id: summary.id,
-                coordinate: .init(latitude: summary.latitude, longitude: summary.longitude),
-                title: summary.title
-            )
-            if let existing = existingAnnotations[summary.id] {
-                if existing.title != new.title {
-                    toRemove.append(existing)
-                    toAdd.append(new)
-                }
-            } else {
+            let new = ObjectAnnotation(id: summary.id, coordinate: .init(latitude: summary.latitude, longitude: summary.longitude), title: summary.title)
+            if let existing = existing[summary.id], existing.title != new.title {
+                toRemove.append(existing)
+                toAdd.append(new)
+            } else if existing[summary.id] == nil {
                 toAdd.append(new)
             }
         }
-        
+
         let newIDs = Set(viewModel.objectSummaries.map { $0.id })
-        for (id, annotation) in existingAnnotations {
-            if !newIDs.contains(id) {
-                toRemove.append(annotation)
-            }
+        for (id, annotation) in existing where !newIDs.contains(id) {
+            toRemove.append(annotation)
         }
-        
-        mapView.removeAnnotations(toRemove)
-        mapView.addAnnotations(toAdd)
+
+        return (toAdd, toRemove)
     }
-    
+
+    private func applyAnnotationChanges(to mapView: MKMapView, add: [ObjectAnnotation], remove: [MKAnnotation]) {
+        mapView.removeAnnotations(remove)
+        mapView.addAnnotations(add)
+    }
+
     class Coordinator: NSObject, MKMapViewDelegate {
         var parent: MapViewRepresentable
         private var hasCenteredOnUser = false
-        
+
         init(_ parent: MapViewRepresentable) {
             self.parent = parent
         }
-        
+
         func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
             guard let objectAnnotation = view.annotation as? ObjectAnnotation else { return }
             parent.viewModel.objectPinTapped(id: objectAnnotation.id)
         }
-        
+
         func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
             if annotation is MKUserLocation { return nil }
-            
-            // Cluster View
             if let cluster = annotation as? MKClusterAnnotation {
-                let identifier = "customClusterView"
-                var clusterView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier)
-                
-                if clusterView == nil {
-                    clusterView = MKAnnotationView(annotation: cluster, reuseIdentifier: identifier)
-                    clusterView?.canShowCallout = false
-                    clusterView?.frame.size = CGSize(width: 44, height: 44)
-                } else {
-                    clusterView?.annotation = cluster
-                }
-                
-                var baseImage = UIImage(systemName: "photo")!
-                
-                if let first = cluster.memberAnnotations
-                    .compactMap({ $0 as? ObjectAnnotation })
-                    .first,
-                   let imageName = parent.viewModel.objectSummaries
-                    .first(where: { $0.id == first.id })?.flowerImage,
-                   let flowerImage = UIImage(named: imageName) {
-                    baseImage = flowerImage.resize(to: CGSize(width: 44, height: 44)) ?? baseImage
-                }
-                
-                let count = cluster.memberAnnotations.count
-                clusterView?.image = makeClusterImageWithBadge(base: baseImage, count: count)
-                return clusterView
+                return createClusterView(for: mapView, cluster: cluster)
             }
-            
-            // Single Pin View
-            let identifier = "customPin"
-            var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier)
-            
-            if annotationView == nil {
-                annotationView = MKAnnotationView(annotation: annotation, reuseIdentifier: identifier)
-                annotationView?.canShowCallout = false
-                annotationView?.clusteringIdentifier = "customPinCluster"
-                annotationView?.frame.size = CGSize(width: 40, height: 40)
-                
-                let titleLabel = UILabel()
-                titleLabel.tag = 1001
-                titleLabel.font = UIFont.systemFont(ofSize: 12)
-                titleLabel.textColor = .black
-                titleLabel.textAlignment = .center
-                titleLabel.numberOfLines = 1
-                titleLabel.backgroundColor = UIColor.white.withAlphaComponent(0.0)
-                titleLabel.layer.cornerRadius = 4
-                titleLabel.layer.masksToBounds = true
-                titleLabel.frame = CGRect(x: -30, y: 60, width: 100, height: 20)
-                
-                annotationView?.addSubview(titleLabel)
-            } else {
-                annotationView?.annotation = annotation
-                annotationView?.clusteringIdentifier = "customPinCluster"
-            }
-            
-            if let objectAnnotation = annotation as? ObjectAnnotation,
-               let imageName = parent.viewModel.objectSummaries.first(where: { $0.id == objectAnnotation.id })?.flowerImage {
-                annotationView?.image = UIImage(named: imageName) ?? UIImage(systemName: "photo")
-            } else {
-                annotationView?.image = UIImage(systemName: "mappin.circle.fill")
-            }
-            
-            if let titleLabel = annotationView?.viewWithTag(1001) as? UILabel {
-                titleLabel.text = annotation.title ?? ""
-                titleLabel.sizeToFit()
-                let labelWidth = titleLabel.frame.width + 10
-                titleLabel.frame.size.width = labelWidth
-                titleLabel.center.x = annotationView!.bounds.width / 2
-            }
-            
-            return annotationView
+            return createCustomPinView(for: mapView, annotation: annotation)
         }
-        
+
         func mapView(_ mapView: MKMapView, didUpdate userLocation: MKUserLocation) {
             if !hasCenteredOnUser {
-                let region = MKCoordinateRegion(
-                    center: userLocation.coordinate,
-                    span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02)
-                )
+                let region = MKCoordinateRegion(center: userLocation.coordinate, span: MKCoordinateSpan(latitudeDelta: 0.02, longitudeDelta: 0.02))
                 mapView.setRegion(region, animated: true)
                 hasCenteredOnUser = true
             }
         }
-        
+
+        private func createClusterView(for mapView: MKMapView, cluster: MKClusterAnnotation) -> MKAnnotationView {
+            let identifier = "customClusterView"
+            var clusterView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) ?? MKAnnotationView(annotation: cluster, reuseIdentifier: identifier)
+            clusterView.annotation = cluster
+            clusterView.canShowCallout = false
+            clusterView.frame.size = CGSize(width: 44, height: 44)
+
+            var baseImage = UIImage(systemName: "photo")!
+            if let first = cluster.memberAnnotations.compactMap({ $0 as? ObjectAnnotation }).first,
+               let imageName = parent.viewModel.objectSummaries.first(where: { $0.id == first.id })?.flowerImage,
+               let flowerImage = UIImage(named: imageName) {
+                baseImage = flowerImage.resize(to: CGSize(width: 44, height: 44)) ?? baseImage
+            }
+
+            clusterView.image = makeClusterImageWithBadge(base: baseImage, count: cluster.memberAnnotations.count)
+            return clusterView
+        }
+
+        private func createCustomPinView(for mapView: MKMapView, annotation: MKAnnotation) -> MKAnnotationView? {
+            let identifier = "customPin"
+            var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) ?? MKAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+            annotationView.annotation = annotation
+            annotationView.canShowCallout = false
+            annotationView.clusteringIdentifier = "customPinCluster"
+            annotationView.frame.size = CGSize(width: 40, height: 40)
+
+            if annotationView.viewWithTag(1001) == nil {
+                annotationView.addSubview(makeTitleLabel())
+            }
+
+            if let objectAnnotation = annotation as? ObjectAnnotation,
+               let imageName = parent.viewModel.objectSummaries.first(where: { $0.id == objectAnnotation.id })?.flowerImage {
+                annotationView.image = UIImage(named: imageName) ?? UIImage(systemName: "photo")
+            } else {
+                annotationView.image = UIImage(systemName: "mappin.circle.fill")
+            }
+
+            if let titleLabel = annotationView.viewWithTag(1001) as? UILabel {
+                titleLabel.text = annotation.title ?? ""
+                titleLabel.sizeToFit()
+                titleLabel.frame.size.width = titleLabel.frame.width + 10
+                titleLabel.center.x = annotationView.bounds.width / 2
+            }
+
+            return annotationView
+        }
+
         private func makeClusterImageWithBadge(base: UIImage, count: Int) -> UIImage {
             let badgeSize: CGFloat = 20
             let font = UIFont.boldSystemFont(ofSize: 14)
-            
             let renderer = UIGraphicsImageRenderer(size: base.size)
+
             return renderer.image { _ in
                 base.draw(in: CGRect(origin: .zero, size: base.size))
-                
-                let badgeRect = CGRect(
-                    x: base.size.width - badgeSize - 2,
-                    y: 2,
-                    width: badgeSize,
-                    height: badgeSize
-                )
-                
+
+                let badgeRect = CGRect(x: base.size.width - badgeSize - 2, y: 2, width: badgeSize, height: badgeSize)
                 let badgePath = UIBezierPath(ovalIn: badgeRect)
                 UIColor.lightGray.withAlphaComponent(0.7).setFill()
                 badgePath.fill()
-                
+
                 let paragraphStyle = NSMutableParagraphStyle()
                 paragraphStyle.alignment = .center
                 let attributes: [NSAttributedString.Key: Any] = [
@@ -226,10 +182,21 @@ struct MapViewRepresentable: UIViewRepresentable {
                 text.draw(in: textRect, withAttributes: attributes)
             }
         }
+
+        private func makeTitleLabel() -> UILabel {
+            let label = UILabel()
+            label.tag = 1001
+            label.font = UIFont.systemFont(ofSize: 12)
+            label.textColor = .black
+            label.textAlignment = .center
+            label.backgroundColor = UIColor.white.withAlphaComponent(0.0)
+            label.layer.cornerRadius = 4
+            label.layer.masksToBounds = true
+            label.frame = CGRect(x: -30, y: 60, width: 100, height: 20)
+            return label
+        }
     }
 }
-
-// MARK: - UIImage Resize Extension
 
 extension UIImage {
     func resize(to size: CGSize) -> UIImage? {

--- a/Packages/Features/Sources/Features/Map/MapViewRepresentable.swift
+++ b/Packages/Features/Sources/Features/Map/MapViewRepresentable.swift
@@ -106,7 +106,7 @@ struct MapViewRepresentable: UIViewRepresentable {
 
         private func createClusterView(for mapView: MKMapView, cluster: MKClusterAnnotation) -> MKAnnotationView {
             let identifier = "customClusterView"
-            var clusterView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) ?? MKAnnotationView(annotation: cluster, reuseIdentifier: identifier)
+            let clusterView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) ?? MKAnnotationView(annotation: cluster, reuseIdentifier: identifier)
             clusterView.annotation = cluster
             clusterView.canShowCallout = false
             clusterView.frame.size = CGSize(width: 44, height: 44)
@@ -124,7 +124,7 @@ struct MapViewRepresentable: UIViewRepresentable {
 
         private func createCustomPinView(for mapView: MKMapView, annotation: MKAnnotation) -> MKAnnotationView? {
             let identifier = "customPin"
-            var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) ?? MKAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+            let annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) ?? MKAnnotationView(annotation: annotation, reuseIdentifier: identifier)
             annotationView.annotation = annotation
             annotationView.canShowCallout = false
             annotationView.clusteringIdentifier = "customPinCluster"

--- a/Packages/Features/Sources/Features/MyRecordView/MyRecordModel.swift
+++ b/Packages/Features/Sources/Features/MyRecordView/MyRecordModel.swift
@@ -1,97 +1,97 @@
+////
+////  MyRecordModel.swift
+////  Features
+////
+////  Created by Jimin on 7/20/25.
+////
 //
-//  MyRecordModel.swift
-//  Features
+//import Foundation
+//import Combine
 //
-//  Created by Jimin on 7/20/25.
+//enum Flower: String, CaseIterable, Codable {
+//    case tulip = "tulip"
+//    case sunflower = "sunflower"
+//    
+//    var displayName: String {
+//        switch self {
+//        case .tulip: return "튤립"
+//        case .sunflower: return "해바라기"
+//        }
+//    }
+//    
+//    var imageName: String {
+//        switch self {
+//        case .tulip: return "flower1"
+//        case .sunflower: return "flower2"
+//        }
+//    }
+//}
 //
-
-import Foundation
-import Combine
-
-enum Flower: String, CaseIterable, Codable {
-    case tulip = "tulip"
-    case sunflower = "sunflower"
-    
-    var displayName: String {
-        switch self {
-        case .tulip: return "튤립"
-        case .sunflower: return "해바라기"
-        }
-    }
-    
-    var imageName: String {
-        switch self {
-        case .tulip: return "flower1"
-        case .sunflower: return "flower2"
-        }
-    }
-}
-
-struct MyRecordModel: Identifiable {
-    let id: UUID
-    let title: String
-    let formattedDate: String
-    let flowerImageName: String
-}
-
-extension MyRecordModel {
-    static func createMock() -> [MyRecordModel] {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "ko_KR")
-        dateFormatter.dateFormat = "yyyy년 M월 d일"
-        
-        let mockData = [
-            (
-                title: "포항공과대학교에서",
-                date: Calendar.current.date(from: DateComponents(year: 2025, month: 6, day: 12))!,
-                flower: Flower.tulip
-            ),
-            (
-                title: "영일대에서 애들이랑",
-                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
-                flower: Flower.sunflower
-            ),
-            (
-                title: "C5 세션이 끝난 뒤",
-                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
-                flower: Flower.sunflower
-            ),
-            (
-                title: "C5 세션이 끝난 뒤",
-                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
-                flower: Flower.sunflower
-            ),
-            (
-                title: "C5 세션이 끝난 뒤",
-                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
-                flower: Flower.sunflower
-            )
-        ]
-        
-        return mockData.map { data in
-            MyRecordModel(
-                id: UUID(),
-                title: data.title,
-                formattedDate: dateFormatter.string(from: data.date),
-                flowerImageName: data.flower.imageName
-            )
-        }.sorted { first, second in
-            let firstDate = mockData.first { $0.title == first.title }?.date ?? Date()
-            let secondDate = mockData.first { $0.title == second.title }?.date ?? Date()
-            return firstDate < secondDate
-        }
-    }
-}
-
-@MainActor
-final class MyRecordViewModel: ObservableObject {
-    @Published var records: [MyRecordModel] = []
-    
-    init() {
-        loadMockData()
-    }
-    
-    private func loadMockData() {
-        records = MyRecordModel.createMock()
-    }
-}
+//struct MyRecordModel: Identifiable {
+//    let id: UUID 
+//    let title: String
+//    let formattedDate: String
+//    let flowerImageName: String
+//}
+//
+//extension MyRecordModel {
+//    static func createMock() -> [MyRecordModel] {
+//        let dateFormatter = DateFormatter()
+//        dateFormatter.locale = Locale(identifier: "ko_KR")
+//        dateFormatter.dateFormat = "yyyy년 M월 d일"
+//        
+//        let mockData = [
+//            (
+//                title: "포항공과대학교에서",
+//                date: Calendar.current.date(from: DateComponents(year: 2025, month: 6, day: 12))!,
+//                flower: Flower.tulip
+//            ),
+//            (
+//                title: "영일대에서 애들이랑",
+//                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
+//                flower: Flower.sunflower
+//            ),
+//            (
+//                title: "C5 세션이 끝난 뒤",
+//                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
+//                flower: Flower.sunflower
+//            ),
+//            (
+//                title: "C5 세션이 끝난 뒤",
+//                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
+//                flower: Flower.sunflower
+//            ),
+//            (
+//                title: "C5 세션이 끝난 뒤",
+//                date: Calendar.current.date(from: DateComponents(year: 2024, month: 3, day: 7))!,
+//                flower: Flower.sunflower
+//            )
+//        ]
+//        
+//        return mockData.map { data in
+//            MyRecordModel(
+//                id: UUID(),
+//                title: data.title,
+//                formattedDate: dateFormatter.string(from: data.date),
+//                flowerImageName: data.flower.imageName
+//            )
+//        }.sorted { first, second in
+//            let firstDate = mockData.first { $0.title == first.title }?.date ?? Date()
+//            let secondDate = mockData.first { $0.title == second.title }?.date ?? Date()
+//            return firstDate < secondDate
+//        }
+//    }
+//}
+//
+//@MainActor
+//final class MyRecordViewModel: ObservableObject {
+//    @Published var records: [MyRecordModel] = []
+//    
+//    init() {
+//        loadMockData()
+//    }
+//    
+//    private func loadMockData() {
+//        records = MyRecordModel.createMock()
+//    }
+//}

--- a/Packages/Features/Sources/Features/MyRecordView/MyRecordView.swift
+++ b/Packages/Features/Sources/Features/MyRecordView/MyRecordView.swift
@@ -10,12 +10,18 @@ import DesignSystem
 
 struct MyRecordView: View {
     @StateObject private var viewModel = MyRecordViewModel()
-    
+    @EnvironmentObject private var nav: NavigationViewModel
+
+    @State private var selectedRecordID: IdentifiableUUID? = nil
+
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
                 HStack {
                     Button(action: {
+                        if !nav.path.isEmpty {
+                            nav.path.removeLast()
+                        }
                     }) {
                         Image(systemName: "chevron.left")
                             .font(.system(size: 24))
@@ -23,27 +29,38 @@ struct MyRecordView: View {
                     }
                     Spacer()
                 }
-                .padding(.horizontal, 20)
                 .padding(.top, 16)
-                
+
                 Text("전체")
                     .font(.system(size: 28, weight: .bold))
                     .foregroundColor(.black)
                     .padding(.vertical, 20)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 20)
-                
+
                 Spacer()
                     .frame(height: 20)
-                
-                RecordList(records: viewModel.records)
-            }
-            .navigationBarHidden(true)
-            
-        }
 
+                RecordList(
+                    records: viewModel.records,
+                    onRecordTap: { id in
+                        selectedRecordID = IdentifiableUUID(id: id)
+                    }
+                )
+            }
+            .padding(.horizontal, 20)
+            .navigationBarHidden(true)
+            .sheet(item: $selectedRecordID) { identifiableID in
+                RecordDetailBottomSheet(viewModel: RecordDetailViewModel(id: identifiableID.id))
+            }
+        }
     }
 }
+
+struct IdentifiableUUID: Identifiable, Equatable {
+    let id: UUID
+}
+
+
 
 #Preview {
     MyRecordView()

--- a/Packages/Features/Sources/Features/MyRecordView/MyRecordViewModel.swift
+++ b/Packages/Features/Sources/Features/MyRecordView/MyRecordViewModel.swift
@@ -1,0 +1,58 @@
+//
+//  SwiftUIView.swift
+//  Features
+//
+//  Created by Woody on 7/25/25.
+//
+
+import Foundation
+
+struct MyRecordModel: Identifiable {
+    let id: UUID
+    let title: String
+    let createdAt: Date
+    let flowerImageName: String
+    
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter.string(from: createdAt)
+    }
+    
+    // MARK: - Mock Creator
+    static func createMock() -> [MyRecordModel] {
+        return MockDataProvider.mockObjects().map { mote in
+            MyRecordModel(
+                id: mote.id,
+                title: mote.title,
+                createdAt: mote.createdAt,
+                flowerImageName: mote.flower.objetImage
+            )
+        }
+    }
+}
+
+import Foundation
+
+final class MyRecordViewModel: ObservableObject {
+    @Published var records: [MyRecordModel] = []
+    
+    init() {
+           loadMockRecords()
+       }
+       
+       private func loadMockRecords() {
+           self.records = MyRecordModel.createMock()
+               .sorted(by: { $0.createdAt > $1.createdAt }) // 최신순 정렬
+           
+           for record in records {
+                   print("🔹 Record ID: \(record.id)")
+                   print("   Title: \(record.title)")
+                   print("   Created At: \(record.formattedDate)")
+                   print("   Flower Image Name: \(record.flowerImageName)")
+               }
+
+       }
+}
+
+

--- a/Packages/Features/Sources/Features/MyRecordView/RecordCard.swift
+++ b/Packages/Features/Sources/Features/MyRecordView/RecordCard.swift
@@ -12,32 +12,30 @@ struct RecordCard: View {
     let record: MyRecordModel
     
     var body: some View {
-        HStack(spacing: 18) {
-            ZStack {
-             /*   Circle()
-                    .fill(Color.green.opacity(0.1))
-                    .frame(width: 66, height: 66)*/
-
-                DesignSystemAssets.image(named: record.flowerImageName)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 66, height: 66)
-            }
+        HStack(spacing: 16) {
+            DesignSystemAssets.image(named: record.flowerImageName)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 50, height: 50)
+                .clipped()
+                .cornerRadius(8)
             
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(record.title)
-                    .font(.system(size: 16, weight: .medium))
+                    .font(.body)
                     .foregroundColor(.primary)
                     .lineLimit(1)
                 
                 Text(record.formattedDate)
-                    .font(.system(size: 14))
+                    .font(.caption)
                     .foregroundColor(.secondary)
             }
             
             Spacer()
         }
-        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 4)
+        
     }
 }
 

--- a/Packages/Features/Sources/Features/MyRecordView/RecordList.swift
+++ b/Packages/Features/Sources/Features/MyRecordView/RecordList.swift
@@ -9,21 +9,29 @@ import SwiftUI
 
 struct RecordList: View {
     let records: [MyRecordModel]
-    
+    let onRecordTap: (UUID) -> Void
+
     var body: some View {
         ScrollView {
-            LazyVStack() {
-                ForEach(records, id: \.id) { record in
-                    RecordCard(record: record)
+            LazyVStack {
+                ForEach(records) { record in
+                    Button(action: {
+                        print("✅ Tapped Record:")
+                         print("ID: \(record.id)")
+                         print("Title: \(record.title)")
+                         print("Date: \(record.formattedDate)")
+                         print("Flower: \(record.flowerImageName)")
+                         
+                         onRecordTap(record.id)
+                        onRecordTap(record.id)
+                    }) {
+                        RecordCard(record: record)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
             }
-            .padding(.horizontal, 20)
         }
     }
 }
 
-#Preview {
-    RecordList(
-        records: MyRecordModel.createMock()
-    )
-}

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -18,6 +18,7 @@ public struct RecordDetailBottomSheet: View {
     }
     
     // MapView에서 데이터 주입을 위해 사용
+    // MyRecordView에서 데이터 주입을 위해
     public init(viewModel: RecordDetailViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -54,10 +54,9 @@ public final class RecordDetailViewModel: ObservableObject {
         // 기본 초기화 시에는 임시 데이터 세팅하거나 안 할 수 있음
     }
     
-    convenience init(summary: ObjectSummary) {
-        self.init()
-        fetchRecordDetails(id: summary.id)
-    }
+    public init(id: UUID) {
+           fetchRecordDetails(id: id)
+       }
     
     // MARK: - Methods
     


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #102 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- RecordDetailViewModel의 초기화 인자를 id 하나로 단순화하여 구조 개선

- MyRecordView에 Mock 데이터를 연결하고 최신순 정렬 적용

- MyRecordCard 클릭 시 RecordDetailBottomSheet가 올라오도록 UI 연동 완료

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3017655a-ca7f-4b02-9d35-d0cbb21de53e" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- MyRecordCard 내부에서 onTapGesture로 selectedRecordID 바인딩하여 BottomSheet 띄움

- 현재는 Mock 데이터로 동작하며, 추후 API 연동 시 별도 처리 필요


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
