### PR TITLE
🛠 Fix: #109 RecordSaveSheetView 원본 구조 복원

### DIFF
--- a/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
@@ -212,8 +212,6 @@ class ARCameraViewModel: NSObject, ObservableObject {
                 // Domain Record로 변환
                 let domainRecord = RecordMapper.toDomainRecord(
                     from: placement,
-                    title: finalRecord.title,
-                    description: finalRecord.description,
                     userLocation: location,
                     images: finalRecord.images
                 )

--- a/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinatorDelegate.swift
+++ b/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinatorDelegate.swift
@@ -30,21 +30,15 @@ struct BottomSheetCoordinatorModifier: ViewModifier {
             FlowerSelectionBottomSheet(
                 viewModel: coordinator.flowerSelectionViewModel
             )
-            .presentationDetents([.medium, .large])
-            .presentationDragIndicator(.visible)
 
         case .recordDetail:
             if let viewModel = coordinator.recordDetailViewModel {
                 RecordDetailBottomSheet(viewModel: viewModel)
-                    .presentationDetents([.medium, .large])
-                    .presentationDragIndicator(.visible)
             }
 
         case .saveSheet:
             if let viewModel = coordinator.saveSheetViewModel {
                 RecordSaveSheetView(viewModel: viewModel)
-                    .presentationDetents([.large])
-                    .presentationDragIndicator(.visible)
             }
         }
     }

--- a/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
@@ -30,8 +30,6 @@ enum RecordMapper {
 
     static func toDomainRecord(
         from placementData: ARPlacementData,
-        title: String,
-        description: String,
         userLocation: CLLocation,
         images: [UIImage]
     ) -> Domain.Record {
@@ -44,12 +42,11 @@ enum RecordMapper {
             id: UUID(),
             authorID: UUID(),  // TODO: Replace with actual author ID
             markerTypeID: placementData.flower.id,
-            title: title,
             coordinate: Domain.Coordinate(
                 latitude: placementData.position.latitude,
                 longitude: placementData.position.longitude
             ),
-            address: Domain.Address(fullAddress: description),
+            address: Domain.Address(fullAddress: ""),
             date: placementData.placedAt,
             photos: photoURLs.map { Domain.Photo(url: $0) },
             isPublic: true  // TODO: Replace with actual visibility if needed

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
@@ -22,24 +22,16 @@ public struct RecordSaveSheetView: View {
         VStack(spacing: 0) {
             RecordSaveHeaderView { dismiss() }
             
-            ScrollView {
-                VStack(spacing: 0) {
-                    SelectedFlowerCardView(
-                        flowerName: viewModel.flowerName,
-                        flowerMeaning: viewModel.flowerMeaning,
-                        flowerImageName: viewModel.flowerImageName
-                    )
-                    .padding(.bottom, 30)
-                    
-                    RecordFormView(
-                        title: $viewModel.title,
-                        description: $viewModel.description
-                    )
+            VStack(spacing: 0) {
+                SelectedFlowerCardView(
+                    flowerName: viewModel.flowerName,
+                    flowerMeaning: viewModel.flowerMeaning,
+                    flowerImageName: viewModel.flowerImageName
+                )
+                .padding(.bottom, 30)
+                
+                PhotoSelectionView(viewModel: viewModel)
                     .padding(.bottom, 20)
-                    
-                    PhotoSelectionView(viewModel: viewModel)
-                        .padding(.bottom, 20)
-                }
             }
             
             SaveButtonView(
@@ -50,7 +42,7 @@ public struct RecordSaveSheetView: View {
             Spacer()
         }
         .padding(.horizontal, 20)
-        .presentationDetents([.large])
+        .presentationDetents([.fraction(0.8)])
         .interactiveDismissDisabled(true)
         .presentationDragIndicator(.hidden)
     }
@@ -122,44 +114,11 @@ private struct SelectedFlowerCardView: View {
     }
 }
 
-private struct RecordFormView: View {
-    @Binding var title: String
-    @Binding var description: String
-    
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("제목")
-                    .font(DesignSystem.Font.custom(size: 16, weight: .semibold))
-                
-                TextField("기록의 제목을 입력해주세요", text: $title)
-                    .font(DesignSystem.Font.custom(size: 15, weight: .regular))
-                    .padding(12)
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
-            }
-            
-            VStack(alignment: .leading, spacing: 8) {
-                Text("내용")
-                    .font(DesignSystem.Font.custom(size: 16, weight: .semibold))
-                
-                TextEditor(text: $description)
-                    .font(DesignSystem.Font.custom(size: 15, weight: .regular))
-                    .frame(height: 100)
-                    .padding(8)
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
-            }
-        }
-    }
-}
-
-
 private struct SaveButtonView: View {
     let isDisabled: Bool
     let viewModel: RecordSaveSheetViewModel
     let dismiss: () -> Void
-
+    
     var body: some View {
         Button(action: {
             viewModel.save()
@@ -177,5 +136,5 @@ private struct SaveButtonView: View {
         .padding(.top, 30)
     }
 }
-        
+
 

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -8,8 +8,6 @@ import SwiftUI
 public final class RecordSaveSheetViewModel: ObservableObject {
 
     // MARK: - Properties
-    @Published var title: String = ""
-    @Published var description: String = ""
     @Published var flowerName: String
     @Published var flowerMeaning: String
     @Published var flowerImageName: String
@@ -29,7 +27,7 @@ public final class RecordSaveSheetViewModel: ObservableObject {
     private let onSave: (FinalRecordData) -> Void
 
     public var isSaveButtonDisabled: Bool {
-        return title.isEmpty || description.isEmpty || selectedImages.isEmpty
+        return selectedAssets.isEmpty
     }
 
     let maxImageCount = 4
@@ -55,9 +53,8 @@ public final class RecordSaveSheetViewModel: ObservableObject {
         Task {
             let finalImages = await fetchSelectedImages()
             let finalData = FinalRecordData(
-                title: title,
-                description: description,
-                images: finalImages
+                images: finalImages,
+                description: ""
             )
             onSave(finalData)
             isLoading = false

--- a/Packages/Features/Sources/Features/Shared/RecordSaveModels.swift
+++ b/Packages/Features/Sources/Features/Shared/RecordSaveModels.swift
@@ -8,7 +8,6 @@ public struct RecordSaveSheetInfo {
 }
 
 public struct FinalRecordData {
-    let title: String
-    let description: String
     let images: [UIImage]
+    let description: String
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #109

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- RecordSaveSheetView의 사진 선택 미리보기 UI 복원
- 사진 선택 시 저장 버튼 활성화 조건 복구

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="250" alt="IMG_2644" src="https://github.com/user-attachments/assets/239a15bb-688a-4913-8fe6-189fe7e88cbb" />
<img width="250" alt="IMG_2645" src="https://github.com/user-attachments/assets/942343a3-4901-431f-a6be-d57281744d98" />


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식