### PR TITLE
Refactor/ #115 위치 권한 및 단발 위치 요청 구조 개선

### DIFF
--- a/Packages/Features/Sources/Features/Main/LocationManager.swift
+++ b/Packages/Features/Sources/Features/Main/LocationManager.swift
@@ -1,152 +1,98 @@
-//
-//  SwiftUIView.swift
-//  Features
-//
-//  Created by Woody on 7/18/25.
-//
-
-//
-//  LocationManager.swift
-//  Features
-//
-//  Simplified permission and location manager
-
 import CoreLocation
 import Foundation
 
 @MainActor
-final class LocationManager: NSObject, ObservableObject,
-    CLLocationManagerDelegate
-{
+final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()
     private let geocoder = CLGeocoder()
-    private var lastGeocodeTime: Date? = nil
+    private var lastGeocodeTime: Date?
+    private var hasStopped = false // ✅ 중복 stop 방지
 
-    /// 현재 권한 상태
     @Published var authorizationStatus: CLAuthorizationStatus = .notDetermined
-    /// 현재 위치
-    @Published var currentLocation: CLLocation? = nil
+    @Published var currentLocation: CLLocation?
     @Published var currentAddress: String = "위치 가져오는 중..."
 
     override init() {
         super.init()
         manager.delegate = self
-        print("LocationManager initialized.")
-        // 즉시 권한 요청 (팝업 표시)
+        manager.desiredAccuracy = kCLLocationAccuracyBest
         manager.requestWhenInUseAuthorization()
+        manager.startUpdatingLocation()
     }
 
-    /// CLLocationManagerDelegate: 권한 상태 변경 콜백
-    nonisolated func locationManagerDidChangeAuthorization(
-        _ manager: CLLocationManager
-    ) {
+    func checkCurrentLocationAuthorization(status: CLAuthorizationStatus) {
+        switch status {
+        case .authorizedWhenInUse, .authorizedAlways:
+            self.authorizationStatus = status
+        case .restricted, .denied:
+            self.authorizationStatus = status
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        @unknown default:
+            break
+        }
+    }
+    
+    func requestLocationAgain() {
+        hasStopped = false
+        manager.startUpdatingLocation()
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
-        // 비동기 Task 안에서 MainActor로 전환 후 호출
         Task { @MainActor in
             self.checkCurrentLocationAuthorization(status: status)
         }
     }
 
-    func checkCurrentLocationAuthorization(status: CLAuthorizationStatus) {
-        print("Location authorization status changed: \(status.rawValue)")
-        switch status {
-        case .authorizedWhenInUse, .authorizedAlways:
-            // Location services enabled
-            manager.startUpdatingLocation()
-            let newStatus = manager.authorizationStatus
-            Task { @MainActor in
-                self.authorizationStatus = newStatus
-            }
-            print(
-                "Authorization granted. Started updating location. New status: \(newStatus.rawValue)"
-            )
-        case .restricted, .denied:
-            // Location services unavailable
-            manager.stopUpdatingLocation()
-            let newStatus = manager.authorizationStatus
-            Task { @MainActor in
-                self.authorizationStatus = newStatus
-            }
-            print(
-                "Authorization denied/restricted. Stopped updating location. New status: \(newStatus.rawValue)"
-            )
-        case .notDetermined:
-            // Request permission if not determined
-            manager.requestWhenInUseAuthorization()
-            print(
-                "Authorization not determined. Requested when in use authorization."
-            )
-        @unknown default:
-            break
-        }
-    }
-
-    /// CLLocationManagerDelegate: 위치 업데이트 콜백
     nonisolated func locationManager(
         _ manager: CLLocationManager,
         didUpdateLocations locations: [CLLocation]
     ) {
         guard let loc = locations.first else { return }
-        print(
-            "Received location update: \(loc.coordinate.latitude), \(loc.coordinate.longitude)"
-        )
+
         Task { @MainActor in
             self.currentLocation = loc
-            print("LocationManager.currentLocation set to: \(loc.coordinate.latitude), \(loc.coordinate.longitude)")
 
-            // 마지막 역지오코딩 호출 시각 체크 (예: 5초 이상 지났을 때만)
+            // 위치 수신 후 바로 stop (중복 방지)
+            if !self.hasStopped {
+                self.manager.stopUpdatingLocation()
+                self.hasStopped = true
+            }
+
             let now = Date()
-            if let lastTime = lastGeocodeTime,
-                now.timeIntervalSince(lastTime) < 5
-            {
-                // 5초 안 지났으면 호출하지 않음
-                print(
-                    "역지오코딩 호출 제한: \(now.timeIntervalSince(lastTime))초 후에 다시 시도"
-                )
+            if let lastTime = self.lastGeocodeTime,
+               now.timeIntervalSince(lastTime) < 5 {
                 return
             }
-            lastGeocodeTime = now
+
+            self.lastGeocodeTime = now
             self.geocode(location: loc)
         }
     }
 
-    /// 위치 → 주소 변환 (역 지오코딩)
     private func geocode(location: CLLocation) {
-        print(
-            "Geocoding location: \(location.coordinate.latitude), \(location.coordinate.longitude)"
-        )
-        geocoder.reverseGeocodeLocation(location) {
-            [weak self] placemarks, error in
-            print(
-                "Reverse geocode callback: placemarks=\(String(describing: placemarks)), error=\(String(describing: error))"
-            )
-            DispatchQueue.main.async {
-                guard let self = self else { return }
+        geocoder.reverseGeocodeLocation(location) { [weak self] placemarks, error in
+            guard let self = self else { return }
+
+            Task { @MainActor in
                 if let placemark = placemarks?.first, error == nil {
                     let province = placemark.administrativeArea ?? ""
                     let city = placemark.locality ?? ""
-                    let address = "\(province) \(city)"
-                    print("주소 : \(province) \(city) ")
-                    self.currentAddress = address
-                    print("LocationManager.currentAddress set to: \(self.currentAddress)")
+                    self.currentAddress = "\(province) \(city)"
                 } else {
-                    print("주소를 가져올 수 없습니다")
                     self.currentAddress = "주소를 가져올 수 없습니다"
-                    print("LocationManager.currentAddress set to: \(self.currentAddress)")
                 }
             }
         }
     }
 
-    /// CLLocationManagerDelegate: 에러 발생 콜백
-    nonisolated func locationManager(
-        _ manager: CLLocationManager,
-        didFailWithError error: Error
-    ) {
-        print("LocationManager encountered an error: \(error)")
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         Task { @MainActor in
-            // 필요시 에러 핸들링
             print("Location error: \(error)")
+            self.currentAddress = "위치를 가져올 수 없습니다"
         }
     }
 }

--- a/Packages/Features/Sources/Features/Main/LocationManager.swift
+++ b/Packages/Features/Sources/Features/Main/LocationManager.swift
@@ -37,6 +37,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         hasStopped = false
         manager.startUpdatingLocation()
     }
+    
 
     // MARK: - CLLocationManagerDelegate
 

--- a/Packages/Features/Sources/Features/Main/MainView.swift
+++ b/Packages/Features/Sources/Features/Main/MainView.swift
@@ -7,7 +7,6 @@ import SwiftUI
 struct MainView: View {
     @EnvironmentObject private var nav: NavigationViewModel
 
-    // MARK: - ViewModels (HEAD의 LocationManager 관리 방식 유지)
     @StateObject private var viewModel = MainViewModel()
 
     @State private var sheetDetent: Detent = .low
@@ -30,6 +29,7 @@ struct MainView: View {
                         sheetDetent: $sheetDetent,
                         isSheetVisible: $isSheetVisible,
                         totalCount: $viewModel.totalCount,
+                        locationManager: viewModel.locationManager,
                         detentOffsets: detentOffsets,
                         bottomSafeArea: geometry.safeAreaInsets.bottom
                     )
@@ -41,10 +41,12 @@ struct MainView: View {
                 .snappy(duration: 0.35, extraBounce: 0.08),
                 value: sheetDetent
             )
+            .onAppear {
+                viewModel.requestCurrentLocation()
+            }
             .onReceive(
                 viewModel.locationManager.$currentLocation.compactMap { $0 }
             ) { location in
-                // 최초 위치 업데이트 시 한 번만 호출
                 guard previousLocation == nil else {
                     handleLocationUpdate(location)
                     return
@@ -60,17 +62,6 @@ struct MainView: View {
 // MARK: - Subviews
 
 extension MainView {
-    private var backgroundGradient: some View {
-        LinearGradient(
-            gradient: Gradient(colors: [
-                DesignSystem.Color.Prime4, DesignSystem.Color.Prime3,
-            ]),
-            startPoint: .top,
-            endPoint: .bottom
-        )
-        .ignoresSafeArea()
-    }
-
     private var content: some View {
         VStack(spacing: 16) {
             currentAddressView
@@ -79,8 +70,6 @@ extension MainView {
             if viewModel.isLoading {
                 ProgressView()
             } else {
-                Text("\(viewModel.totalCount)")
-                Text("\(viewModel.nearbyCount)")
                 Text(
                     viewModel.nearbyCount == 0
                         ? "주변에 과거에 기록한 꽃이 없어요" : "주변에 과거에 기록한 꽃이 있어요"
@@ -101,10 +90,6 @@ extension MainView {
                 }
             })
 
-            Button("디자인 시스템 예제 보기") {
-                nav.push(.designSystemExample)
-            }
-
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -120,20 +105,30 @@ extension MainView {
     }
 
     private var currentAddressView: some View {
-        HStack {
+        HStack(spacing: 8) {
             Image(systemName: "paperplane.fill")
                 .foregroundColor(.blue)
+
             Text(viewModel.currentAddress)
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(.blue)
+
+            Button(action: {
+                viewModel.requestCurrentLocation()
+            }) {
+                Image(systemName: "arrow.clockwise.circle.fill")
+                    .foregroundColor(.blue)
+            }
+            .buttonStyle(.plain)
         }
+        .padding(.horizontal)
     }
+
 }
 
 // MARK: - Helpers
 
 extension MainView {
-
     private func handleLocationUpdate(_ location: CLLocation) {
         guard let prev = previousLocation else {
             previousLocation = location
@@ -144,11 +139,6 @@ extension MainView {
         if distance < updateThresholdMeters { return }
 
         previousLocation = location
-
         viewModel.loadNearbyMotesMock(center: location, radius: 1000)
     }
-}
-
-#Preview {
-    MainView()
 }

--- a/Packages/Features/Sources/Features/Main/MainView.swift
+++ b/Packages/Features/Sources/Features/Main/MainView.swift
@@ -88,6 +88,9 @@ extension MainView {
                         )
                     )
                 }
+                else {
+                    print("안됨")
+                }
             })
 
             Spacer()

--- a/Packages/Features/Sources/Features/Main/MainViewModel.swift
+++ b/Packages/Features/Sources/Features/Main/MainViewModel.swift
@@ -15,22 +15,21 @@ public final class MainViewModel: ObservableObject {
     @Published public var isLoading: Bool = false
     @Published public var errorMessage: String?
 
-    // MARK: - Private
     let locationManager = LocationManager()
     private var cancellables = Set<AnyCancellable>()
 
-    // MARK: - Dependencies
     @Dependency(\.fetchMyRecordsUseCase) private var fetchMyRecordsUseCase
 
     public init() {
-        setupLocationSubscriptions()
+        setupAuthorizationSubscription()
         setupAddressGeocoding()
     }
-    
-    // MARK: - Public Methods
-    public func updateLocation(_ location: CLLocation) {
-        self.currentLocation = location
+
+
+    public func requestCurrentLocation() {
+        locationManager.requestLocationAgain()
     }
+    
 
     public func loadNearbyMotesMock(center: CLLocation, radius: Double) {
         isLoading = true
@@ -39,12 +38,6 @@ public final class MainViewModel: ObservableObject {
         Task {
             let allMotes = MockDataProvider.mockObjects()
             self.totalCount = allMotes.count
-            
-            // 🌸 전체 꽃 이름 출력
-            print("🌸 전체 꽃 목록:")
-            for mote in allMotes {
-                print("- \(mote.title)")
-            }
 
             let nearby = allMotes.filter { mote in
                 let distance = haversineDistance(
@@ -58,16 +51,11 @@ public final class MainViewModel: ObservableObject {
 
             self.nearbyCount = nearby.count
             self.isLoading = false
-            
-            // ✅ 전체 개수 출력
-            print("🌸 전체 꽃 개수: \(self.totalCount)")
-            print("🌸 근처 꽃 개수: \(self.nearbyCount)")
         }
     }
 
-    // Haversine 거리 계산 (미터 단위)
     private func haversineDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double) -> Double {
-        let R = 6371000.0 // 지구 반지름 (m)
+        let R = 6371000.0
         let dLat = (lat2 - lat1) * .pi / 180
         let dLon = (lon2 - lon1) * .pi / 180
         let a = sin(dLat / 2) * sin(dLat / 2) +
@@ -76,25 +64,11 @@ public final class MainViewModel: ObservableObject {
         let c = 2 * atan2(sqrt(a), sqrt(1 - a))
         return R * c
     }
-    
-    // MARK: - Subscription Setup
-    private func setupLocationSubscriptions() {
+
+    private func setupAuthorizationSubscription() {
         locationManager.$authorizationStatus
             .receive(on: DispatchQueue.main)
             .assign(to: &$authorizationStatus)
-        
-        locationManager.$currentLocation
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] location in
-                guard let self = self else { return }
-                self.currentLocation = location
-                print("MainViewModel received currentLocation: \(location?.coordinate.longitude)")
-                // Automatically load motes when location updates
-                if let location = location {
-                    self.loadNearbyMotesMock(center: location, radius: 1000)
-                }
-            }
-            .store(in: &cancellables)
     }
 
     private func setupAddressGeocoding() {
@@ -102,7 +76,6 @@ public final class MainViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] address in
                 self?.currentAddress = address
-                print("MainViewModel received currentAddress: \(address)")
             }
             .store(in: &cancellables)
     }

--- a/Packages/Features/Sources/Features/Main/MainViewModel.swift
+++ b/Packages/Features/Sources/Features/Main/MainViewModel.swift
@@ -23,6 +23,7 @@ public final class MainViewModel: ObservableObject {
     public init() {
         setupAuthorizationSubscription()
         setupAddressGeocoding()
+        setupLocationBinding()
     }
 
 
@@ -30,6 +31,15 @@ public final class MainViewModel: ObservableObject {
         locationManager.requestLocationAgain()
     }
     
+    private func setupLocationBinding() {
+        locationManager.$currentLocation
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] loc in
+                self?.currentLocation = loc
+            }
+            .store(in: &cancellables)
+    }
+
 
     public func loadNearbyMotesMock(center: CLLocation, radius: Double) {
         isLoading = true

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/CustomModalView.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/CustomModalView.swift
@@ -35,7 +35,7 @@ struct CustomModalView: View {
     @Binding var totalCount: Int
     
     @StateObject private var viewModel = MyRecordBottomSheetViewModel()
-    @StateObject private var locationManager = LocationManager()
+    @ObservedObject var locationManager: LocationManager
     @EnvironmentObject private var nav: NavigationViewModel
     
     let detentOffsets: (large: CGFloat, low: CGFloat)
@@ -240,13 +240,10 @@ struct CustomModalView: View {
         
         .onReceive(locationManager.$currentLocation.compactMap { $0 }) { location in
             viewModel.filterMotesByLocation(currentLocation: location)
-            
         }
         .onAppear {
             viewModel.loadAllMotes()
-            if let current = locationManager.currentLocation {
-                viewModel.filterMotesByLocation(currentLocation: current)
-            }
+            locationManager.requestLocationAgain()
         }
         
         


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?

### 📌 관련 이슈 (Related Issue)
- Closes #115 

---

### 🧶 주요 변경 내용 (Summary)

- `LocationManager`에서 `startUpdatingLocation()` → `stopUpdatingLocation()` 구조로 변경하여 앱 실행 직후 빠르게 위치 수신
- `requestLocationOnce()` 제거 및 필요 시 수동 호출을 위한 `requestLocationAgain()` 도입
- `MainViewModel`에서 `LocationManager`의 `@Published` 속성과 Combine을 통해 상태 연동
- `CLLocationManagerDelegate` 메서드는 `nonisolated + Task { @MainActor in }` 패턴을 사용하여 데이터 레이스 방지
-  불필요한 상태 변수(`isFirstUpdate`) 제거
- Customodal LocationManager @Observable로 받음 -> 바로 반영될 수 있도록

---

### 📸 스크린샷 (Optional)

<img width="300" alt="위치 수신 UI 예시" src="https://example.com/screenshot.png">

---

### 🧪 테스트 / 검증 내역

- [x] 위치 권한 요청 시 시스템 alert 정상 출력 확인
- [x] 위치 수신 후 주소로 변환 및 상태 업데이트 정상 작동
- [x] `MainViewModel`과의 바인딩을 통해 뷰에서도 주소 반영 확인
- [x] 재요청 버튼을 통해 `requestLocationAgain()` 호출 정상 작동
- [x] iPhone 15 Pro, iOS 17.5.1 환경 테스트 완료
- [ ] 다크모드 대응은 이후 별도 이슈로 처리 예정 (#999)

---

### 💬 기타 공유 사항

- Refresh 버튼 UI적 회의 필요 지금은 일단 위치 표시되는 곳 옆에 놓았습니다.
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)


---

🔖 **Tag**: `#refactor #location #swift #combine #mainactor`
