### PR TITLE
♻️ Refactor: #118 Alert 및 꽃 선택/취소 플로우 구조 개선

### DIFF
--- a/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
@@ -12,9 +12,15 @@ public struct ARCameraView: View {
     @State private var showPermissionAlert = false
 
     public init(location: CLLocation) {
-        _viewModel = StateObject(
-            wrappedValue: ARCameraViewModel(location: location)
+        // 1) Coordinator 생성
+        let coordinator = BottomSheetCoordinator()
+        // 2) ViewModel 생성 시 DI
+        let viewModel = ARCameraViewModel(
+            location: location,
+            bottomSheetCoordinator: coordinator
         )
+        // 3) StateObject에 래핑
+        _viewModel = StateObject(wrappedValue: viewModel)
     }
 
     public var body: some View {

--- a/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
@@ -9,53 +9,64 @@ import SwiftUI
 
 @MainActor
 class ARCameraViewModel: NSObject, ObservableObject {
-
+    
     // MARK: - Published Properties (직접 관리)
     @Published var statusMessage: String = "AR 세션을 시작합니다..."
     @Published var cameraMode: ARCameraMode = .normal
     @Published var isPlacementConfirmed: Bool = false
     @Published var isLoadingRecords: Bool = false
     @Published var isSavingRecord: Bool = false
-
+    
     // MARK: - Coordinators
-    let bottomSheetCoordinator = BottomSheetCoordinator()
-
+    @Published var bottomSheetCoordinator: BottomSheetCoordinator
+    
     // MARK: - Private Properties
     private let arSceneManager = ARSceneManager()
     private let locationManager = CLLocationManager()
     private let transformUseCase = TransformCoordinateUseCase()
     private let location: CLLocation
     private var allRecords: [ARRecordModel] = []
-
+    
     // MARK: - Dependencies (UseCase 주입) - 현재 주석 처리
     // @Dependency(\.fetchMyRecordsUseCase) private var fetchMyRecordsUseCase
     // @Dependency(\.saveRecordUseCase) private var saveRecordUseCase
-
+    
     // MARK: - Placement State
     private var currentPlacement: ARPlacementData?
-
+    
     // MARK: - Initialization
-    init(location: CLLocation) {
+    init(
+        location: CLLocation,
+        bottomSheetCoordinator: BottomSheetCoordinator
+    ) {
         self.location = location
+        self.bottomSheetCoordinator = bottomSheetCoordinator
+        
         super.init()
+        
+        // 이제 안전하게 self를 캡처할 수 있으므로 여기서 콜백을 바인딩
+        self.bottomSheetCoordinator.onCancelPlacement = { [weak self] in
+            self?.cancelPlacement()
+        }
+        
         setupCoordinators()
         setupARSceneManager()
     }
-
+    
     private func setupCoordinators() {
         bottomSheetCoordinator.delegate = self
     }
-
+    
     private func setupARSceneManager() {
         arSceneManager.onRecordTapped = { [weak self] record in
             self?.handleRecordTapped(record)
         }
-
+        
         arSceneManager.onPlacementStateChanged = { [weak self] status in
             self?.handlePlacementStateChanged(status)
         }
     }
-
+    
     // MARK: - Public Methods
     func setupARView(_ arView: ARView) {
         arSceneManager.setupARView(arView)
@@ -63,13 +74,13 @@ class ARCameraViewModel: NSObject, ObservableObject {
         locationManager.requestWhenInUseAuthorization()
         locationManager.startUpdatingHeading()
     }
-
+    
     func startARSession() {
         Task {
             await fetchAndPlaceRecords()
         }
     }
-
+    
     // MARK: - AR Actions
     func switchToPlacementMode() {
         print("🎯 switchToPlacementMode 호출됨")
@@ -80,20 +91,20 @@ class ARCameraViewModel: NSObject, ObservableObject {
         bottomSheetCoordinator.showFlowerSelection()
         print("🎯 꽃 선택 시트 표시 요청됨")
     }
-
+    
     func cancelPlacement() {
         currentPlacement = nil
         arSceneManager.removePlacementObject()
         cameraMode = .normal
         statusMessage = "배치를 취소했습니다."
     }
-
+    
     func confirmPlacement() {
         guard let placement = currentPlacement else {
             statusMessage = "배치할 객체가 없습니다."
             return
         }
-
+        
         arSceneManager.confirmPlacement()
         currentPlacement = ARPlacementData(
             flower: placement.flower,
@@ -104,10 +115,10 @@ class ARCameraViewModel: NSObject, ObservableObject {
         isPlacementConfirmed = true
         statusMessage = "배치가 확정되었습니다. 저장 버튼을 눌러 기록을 저장하세요."
     }
-
+    
     func repositionPlacement() {
         guard let placement = currentPlacement else { return }
-
+        
         currentPlacement = ARPlacementData(
             flower: placement.flower,
             position: placement.position,
@@ -117,20 +128,20 @@ class ARCameraViewModel: NSObject, ObservableObject {
         arSceneManager.startRepositioning()
         statusMessage = "꽃을 다시 배치하세요."
     }
-
+    
     func requestSave() {
         guard let placement = currentPlacement else { return }
-
+        
         // 현재 위치 정보를 가져와서 주소로 변환
         fetchAddress(from: location) { [weak self] address in
             guard let self else { return }
-
+            
             let saveSheetInfo = RecordSaveSheetInfo(
                 flower: placement.flower,
                 location: self.location,
                 address: address ?? "주소를 찾을 수 없음"
             )
-
+            
             self.bottomSheetCoordinator.showSaveSheet(
                 info: saveSheetInfo,
                 onSave: { [weak self] finalRecord in
@@ -138,11 +149,14 @@ class ARCameraViewModel: NSObject, ObservableObject {
                         placement: placement,
                         finalRecord: finalRecord
                     )
+                },
+                onCancel: { [weak self] in
+                    self?.cancelPlacement()
                 }
             )
         }
     }
-
+    
     // MARK: - Private Methods
     private func fetchAddress(
         from location: CLLocation,
@@ -161,7 +175,7 @@ class ARCameraViewModel: NSObject, ObservableObject {
     private func handleRecordTapped(_ record: ARRecordModel) {
         bottomSheetCoordinator.showRecordDetail(record: record)
     }
-
+    
     private func handlePlacementStateChanged(_ status: ARPlacementState.Status)
     {
         switch status {
@@ -173,26 +187,26 @@ class ARCameraViewModel: NSObject, ObservableObject {
             statusMessage = "배치가 확정되었습니다. 저장 버튼을 눌러 기록을 저장하세요."
         }
     }
-
+    
     private func handleFlowerSelected(_ flower: FlowerModel) {
         print("🌸 handleFlowerSelected 호출됨: \(flower.name)")
-
+        
         let arFlower = RecordMapper.toARFlower(from: flower)
         print("🌸 ARFlower 변환 완료: \(arFlower.name)")
-
+        
         // TODO: 실제 배치 위치 계산 로직 필요
         let placementPosition = ARCoordinate(
             latitude: location.coordinate.latitude,
             longitude: location.coordinate.longitude
         )
-
+        
         currentPlacement = ARPlacementData(
             flower: arFlower,
             position: placementPosition,
             isConfirmed: false
         )
         print("🌸 Placement 데이터 설정 완료")
-
+        
         arSceneManager.placeTemporaryObject(flower: arFlower) {
             [weak self] message in
             print("🌸 AR 배치 메시지: \(message)")
@@ -200,13 +214,13 @@ class ARCameraViewModel: NSObject, ObservableObject {
         }
         print("🌸 AR 배치 요청 완료")
     }
-
+    
     private func handleSaveRecord(
         placement: ARPlacementData,
         finalRecord: FinalRecordData
     ) {
         isSavingRecord = true
-
+        
         Task {
             do {
                 // Domain Record로 변환
@@ -215,16 +229,16 @@ class ARCameraViewModel: NSObject, ObservableObject {
                     userLocation: location,
                     images: finalRecord.images
                 )
-
+                
                 // TODO: UseCase를 통해 저장
                 // try await saveRecordUseCase(domainRecord)
-
+                
                 // Mock: 저장 시뮬레이션
                 try await Task.sleep(nanoseconds: 1_000_000_000)  // 1초 대기
                 print(
                     "Mock: Record saved - \(domainRecord.title ?? "Untitled")"
                 )
-
+                
                 statusMessage = "성공적으로 저장되었습니다."
                 isSavingRecord = false
                 currentPlacement = nil
@@ -236,10 +250,10 @@ class ARCameraViewModel: NSObject, ObservableObject {
             }
         }
     }
-
+    
     private func fetchAndPlaceRecords() async {
         isLoadingRecords = true
-
+        
         do {
             // TODO: UseCase를 통해 내 주변 기록들 가져오기
             // let recordDetails = try await fetchMyRecordsUseCase(
@@ -249,10 +263,10 @@ class ARCameraViewModel: NSObject, ObservableObject {
             //     )
             // )
             // let domainRecords = recordDetails.map { $0.record }
-
+            
             // Mock: 가짜 데이터 생성
             let domainRecords = makeMockDomainRecords()
-
+            
             // Domain Record를 AR용 모델로 변환
             allRecords = RecordMapper.toARRecordModels(from: domainRecords)
             statusMessage = "\(allRecords.count)개의 기록을 불러왔습니다."
@@ -260,10 +274,10 @@ class ARCameraViewModel: NSObject, ObservableObject {
         } catch {
             statusMessage = "네트워크 오류: \(error.localizedDescription)"
         }
-
+        
         isLoadingRecords = false
     }
-
+    
     private func updateSceneWithRecords() {
         guard let userHeading = locationManager.heading else { return }
         arSceneManager.updateSceneWithRecords(
@@ -273,17 +287,17 @@ class ARCameraViewModel: NSObject, ObservableObject {
             transformUseCase: transformUseCase
         )
     }
-
+    
     // MARK: - Mock Data Generation
     private func makeMockDomainRecords() -> [Domain.Record] {
         let titles = ["행복했던 강아지와의 산책", "맛있는 점심", "개발 공부"]
-
+        
         return titles.map { title in
             let randomCoordinate = generateRandomCoordinate(
                 center: self.location.coordinate,
                 radiusInMeters: 5.0  // 5미터 반경으로 축소
             )
-
+            
             return Domain.Record(
                 id: UUID(),
                 authorID: UUID(),
@@ -302,21 +316,21 @@ class ARCameraViewModel: NSObject, ObservableObject {
             )
         }
     }
-
+    
     private func generateRandomCoordinate(
         center: CLLocationCoordinate2D,
         radiusInMeters: Double
     ) -> CLLocationCoordinate2D {
         let radiusInDegrees = radiusInMeters / 111_111.0
-
+        
         let angle = Double.random(in: 0..<(2 * .pi))
         let radius = sqrt(Double.random(in: 0..<1)) * radiusInDegrees
-
+        
         let newLatitude = center.latitude + radius * cos(angle)
         let newLongitude =
-            center.longitude + radius * sin(angle)
-            / cos(center.latitude * .pi / 180.0)
-
+        center.longitude + radius * sin(angle)
+        / cos(center.latitude * .pi / 180.0)
+        
         return CLLocationCoordinate2D(
             latitude: newLatitude,
             longitude: newLongitude
@@ -342,7 +356,7 @@ extension ARCameraViewModel: CLLocationManagerDelegate {
             updateSceneWithRecords()
         }
     }
-
+    
     nonisolated func locationManager(
         _ manager: CLLocationManager,
         didUpdateHeading newHeading: CLHeading
@@ -351,7 +365,7 @@ extension ARCameraViewModel: CLLocationManagerDelegate {
             updateSceneWithRecords()
         }
     }
-
+    
     nonisolated func locationManager(
         _ manager: CLLocationManager,
         didFailWithError error: Error

--- a/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
+++ b/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
@@ -26,9 +26,16 @@ class BottomSheetCoordinator: ObservableObject {
 
     // MARK: - Delegate
     weak var delegate: BottomSheetCoordinatorDelegate?
+    
+    var onCancelPlacement: () -> Void = {}
 
     init() {
         setupFlowerSelectionCallback()
+    }
+    
+    func cancelPlacement() {
+        onCancelPlacement()
+        dismissSheet()
     }
 
     private func setupFlowerSelectionCallback() {
@@ -79,7 +86,8 @@ class BottomSheetCoordinator: ObservableObject {
 
     func showSaveSheet(
         info: RecordSaveSheetInfo,
-        onSave: @escaping (FinalRecordData) -> Void
+        onSave: @escaping (FinalRecordData) -> Void,
+        onCancel: @escaping () -> Void
     ) {
         print("📱 showSaveSheet 호출됨: \(info.flower.name)")
 
@@ -91,6 +99,7 @@ class BottomSheetCoordinator: ObservableObject {
             }
         )
         self.saveSheetViewModel = viewModel
+        self.onCancelPlacement = onCancel
         self.activeSheet = .saveSheet
         print("📱 SaveSheet 설정 ���료")
     }

--- a/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinatorDelegate.swift
+++ b/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinatorDelegate.swift
@@ -38,7 +38,12 @@ struct BottomSheetCoordinatorModifier: ViewModifier {
 
         case .saveSheet:
             if let viewModel = coordinator.saveSheetViewModel {
-                RecordSaveSheetView(viewModel: viewModel)
+                RecordSaveSheetView(
+                    viewModel: viewModel,
+                    onCancelPlacement: {
+                        coordinator.cancelPlacement()
+                    }
+                )
             }
         }
     }

--- a/Packages/Features/Sources/Features/ARCamera/Components/ARTopBarView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Components/ARTopBarView.swift
@@ -4,16 +4,32 @@
 //
 //  Created by eunsong on 7/26/25.
 //
+
 import SwiftUI
 import DesignSystem
 
 struct ARTopBarView: View {
     let onClose: () -> Void
+    @State private var showCancelAlert = false
 
     var body: some View {
         HStack {
             Spacer()
-            ARCancelButton(action: onClose)
+            ARCancelButton {
+                showCancelAlert = true
+            }
+        }
+        .alert(
+            "꽃 심기를 그만두실래요?",
+            isPresented: $showCancelAlert
+        ) {
+            Button("그만둘래요", role: .destructive) {
+                onClose()
+            }
+            Button("계속할래요", role: .cancel) {
+            }
+        } message: {
+            Text("방금 배치한 꽃은 사라지게 됩니다")
         }
     }
 }

--- a/Packages/Features/Sources/Features/FlowerSelect/FlowerSelectionBottomSheet.swift
+++ b/Packages/Features/Sources/Features/FlowerSelect/FlowerSelectionBottomSheet.swift
@@ -16,6 +16,8 @@ struct FlowerSelectionBottomSheet: View {
             titleView
             flowerListView
         }
+        .presentationDetents([.fraction(0.3)])
+        .presentationDragIndicator(.visible)
         .padding(.top, 16)
     }
 }

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
@@ -13,14 +13,25 @@ import DesignSystem
 public struct RecordSaveSheetView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: RecordSaveSheetViewModel
+    private let onCancelPlacement: () -> Void
     
-    public init(viewModel: RecordSaveSheetViewModel) {
+    public init(
+        viewModel: RecordSaveSheetViewModel,
+        onCancelPlacement: @escaping () -> Void
+    ) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        self.onCancelPlacement = onCancelPlacement
     }
     
     public var body: some View {
         VStack(spacing: 0) {
-            RecordSaveHeaderView { dismiss() }
+            RecordSaveHeaderView(
+                onRequestCancel: { },
+                onConfirmCancel: {
+                    onCancelPlacement()
+                    dismiss()
+                }
+            )
             
             VStack(spacing: 0) {
                 SelectedFlowerCardView(
@@ -51,13 +62,18 @@ public struct RecordSaveSheetView: View {
 // MARK: - Subviews
 
 private struct RecordSaveHeaderView: View {
-    let onClose: () -> Void
+    let onRequestCancel: () -> Void
+    let onConfirmCancel: () -> Void
+    @State private var showCancelAlert = false
     
     var body: some View {
         VStack(spacing: 8) {
             HStack {
                 Spacer()
-                Button(action: onClose) {
+                Button(action: {
+                    showCancelAlert = true
+                    onRequestCancel()
+                }) {
                     ZStack {
                         Circle()
                             .fill(Color(red: 0.45, green: 0.51, blue: 0.59).opacity(0.16))
@@ -67,6 +83,18 @@ private struct RecordSaveHeaderView: View {
                             .font(.system(size: 14, weight: .medium))
                             .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15).opacity(0.25))
                     }
+                }
+                .alert(
+                    "꽃 심기를 그만두실래요?",
+                    isPresented: $showCancelAlert
+                ) {
+                    Button("그만둘래요", role: .destructive) {
+                        onConfirmCancel()
+                    }
+                    Button("계속할래요", role: .cancel) {
+                    }
+                } message: {
+                    Text("방금 배치한 꽃은 사라지게 됩니다")
                 }
             }
             

--- a/Packages/Features/Sources/Features/RecordSave/SwiftUIView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/SwiftUIView.swift
@@ -62,7 +62,12 @@ public struct SwiftUIView: View {
                         // 필요하다면 savedRecords에 추가하는 로직을 구현할 수 있습니다.
                     }
                 )
-                RecordSaveSheetView(viewModel: viewModel)
+                RecordSaveSheetView(
+                    viewModel: viewModel,
+                    onCancelPlacement: {
+                        isShowingSaveSheet = false
+                    }
+                )
             }
 //            .sheet(item: $selectedRecord) { record in
 //                RecordDetailBottomSheet(


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #118 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- FlowerSelectionBottomSheet의 detent 구조 수정
- ARCancelButton → .alert(...) 호출
(SwiftUI .alert는 버튼이 2개일 때 가로 배치되는 iOS UX 가이드 반영)
- BottomSheetCoordinator에 onCancelPlacement 클로저 주입 및 래핑 메서드 추가
- ARCameraViewModel 생성자에서 클로저 캡처 시점 오류 해결
- showSaveSheet(info:onSave:onCancel:) 구조 통일 및 호출부에서 onCancel 명시적 전달
- RecordSaveSheetView의 “X” 버튼 → alert 처리 및 onCancelPlacement() 연동

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->


---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 제목 수정하는 DetailBottomSheet에서 키보드 내려가는 작업 
- MapView 내에 백버튼
- 뷰모델 내에서 유즈케이스로 어떤 데이터를 가져올지는 
-금일 내로 작업 예정입니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
