### PR TITLE
✨ Feat. / 123 기록 선택 시 상세보기 시트 띄우는 기능 추가

### DIFF
--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/CustomModalView.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/CustomModalView.swift
@@ -49,6 +49,9 @@ struct CustomModalView: View {
     @State private var isDraggingUp = false      // .low -> .large 전환 중
     @State private var isDraggingDown = false    // .large -> .low 전환 중
     
+    
+    @State private var selectedRecordID: IdentifiableUUID? = nil
+
     var body: some View {
         let isLarge = (sheetDetent == .large)
         let currentOffset: CGFloat = isLarge ? detentOffsets.large : detentOffsets.low
@@ -116,7 +119,11 @@ struct CustomModalView: View {
                                 
                                 FilteredMoteListView(
                                     filteredMotes: viewModel.filteredMotes,
-                                    currentAddress: locationManager.currentAddress
+                                    currentAddress: locationManager.currentAddress,
+                                    onRecordTap: { id in
+                                        selectedRecordID = IdentifiableUUID(id: id)
+
+                                    }
                                 )
                                 
                                 VStack{}.frame(height: 20)
@@ -245,9 +252,11 @@ struct CustomModalView: View {
             viewModel.loadAllMotes()
             locationManager.requestLocationAgain()
         }
-        
-        
         .ignoresSafeArea(.all)
+        .sheet(item: $selectedRecordID) { identifiableID in
+            RecordDetailBottomSheet(viewModel: RecordDetailViewModel(id: identifiableID.id))
+        }
+
     }
     
     private var grabberArea: some View {

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/FilteredMoteListView.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/FilteredMoteListView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct FilteredMoteListView: View {
     let filteredMotes: [Mote]
     let currentAddress: String
+    let onRecordTap: (UUID) -> Void
+
 
     var body: some View {
         if !filteredMotes.isEmpty {
@@ -23,7 +25,12 @@ struct FilteredMoteListView: View {
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
                 ForEach(filteredMotes, id: \.id) { mote in
-                    MoteItemView(mote: mote)
+                    Button {
+                        onRecordTap(mote.id)
+                                       } label: {
+                                           MoteItemView(mote: mote)
+                                       }
+                                       .buttonStyle(.plain)
                 }
             }
             .padding(.bottom,36)

--- a/Packages/Features/Sources/Features/MyRecordView/RecordList.swift
+++ b/Packages/Features/Sources/Features/MyRecordView/RecordList.swift
@@ -23,7 +23,6 @@ struct RecordList: View {
                          print("Flower: \(record.flowerImageName)")
                          
                          onRecordTap(record.id)
-                        onRecordTap(record.id)
                     }) {
                         RecordCard(record: record)
                             .padding(.vertical, 8)


### PR DESCRIPTION
## ✨ Feat: 기록 선택 시 상세보기 시트 띄우는 기능 추가

### 📌 관련 이슈 (Related Issue)
- Closes #123

---

### 🧶 주요 변경 내용 (Summary)

- `FilteredMoteListView`에 `onRecordTap` 콜백 추가하여 기록 아이템 선택 핸들링
- `CustomModalView`에서 기록 선택 시 UUID를 `IdentifiableUUID`로 래핑하여 시트 바인딩
- `.sheet(item:)` 구문을 통해 `RecordDetailBottomSheet`를 동적으로 노출
- UUID를 SwiftUI에서 사용할 수 있도록 `IdentifiableUUID` 타입 정의

---

### 📸 스크린샷 (Optional)

<!-- 필요시 스크린샷 삽입 -->
<!-- 예시:
<img width="300" alt="기록 상세 보기 시트 예시" src="https://...">
-->

---

### 🧪 테스트 / 검증 내역

- [x] 기록 아이템 탭 시 상세 시트 정상 표시 확인
- [x] iPhone 16, iOS 18.5 환경에서 정상 동작
- [ ] 다크모드 대응은 추후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항

---

### 🙇🏻‍♀️ 리뷰 가이드
