### PR TITLE
✨ Feat: #125 MapView 백버튼 및 터치/입력 UX 개선

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/Components/DSButton.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Components/DSButton.swift
@@ -221,10 +221,14 @@ public func ARCancelButton(action: @escaping () -> Void) -> some View {
     .buttonStyle(PlainButtonStyle())
 }
 
-struct MyLocationButton: View {
+public struct MyLocationButton: View {
     let action: () -> Void
+    
+    public init(action: @escaping () -> Void) {
+        self.action = action
+    }
 
-    var body: some View {
+    public var body: some View {
         Button(action: action) {
             Image(systemName: "location")
                 .foregroundColor(DesignSystem.Color.Prime)

--- a/Packages/Features/Sources/Features/Map/MapView.swift
+++ b/Packages/Features/Sources/Features/Map/MapView.swift
@@ -7,31 +7,24 @@
 
 import SwiftUI
 import MapKit
+import DesignSystem
 
 public struct MapView: View {
-    
     @StateObject private var viewModel = MapViewModel()
-    
     @State private var moveToUserLocation = false
+    @EnvironmentObject private var nav: NavigationViewModel
     
     public init() {}
     
     public var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            MapViewRepresentable(viewModel: viewModel, moveToUserLocation: $moveToUserLocation)
-                .ignoresSafeArea()
+        ZStack {
+            MapViewRepresentable(
+                viewModel: viewModel,
+                moveToUserLocation: $moveToUserLocation
+            )
+            .ignoresSafeArea()
             
-            // '내 위치로' 버튼
-            Button {
-                moveToUserLocation = true
-            } label: {
-                Image(systemName: "location.fill")
-                    .padding()
-                    .background(.white)
-                    .clipShape(Circle())
-                    .shadow(radius: 5)
-            }
-            .padding()
+            uiControls
         }
         .onAppear {
             viewModel.fetchMapObjects()
@@ -40,7 +33,49 @@ public struct MapView: View {
             RecordDetailBottomSheet(viewModel: RecordDetailViewModel(id: summary.id))
         }
     }
+    
+    // MARK: - Composed Subviews
+    
+    @ViewBuilder
+    private var uiControls: some View {
+        VStack {
+            HStack(alignment: .top) {
+                topBar
+                
+                Spacer()
+                
+                locationButton
+                    .padding(.top, 52)
+                    .padding(.trailing, 20)
+            }
+            
+            Spacer()
+        }
+    }
+    
+    @ViewBuilder
+    private var topBar: some View {
+        Button {
+            nav.pop()
+        } label: {
+            Image(systemName: "chevron.left")
+                .font(.system(size: 24, weight: .bold))
+                .foregroundColor(.white)
+                .padding(12)
+        }
+        .padding(.top, 8)
+        .padding(.leading, 8)
+    }
+    
+    /// 우하단 내 위치로 이동 버튼
+    @ViewBuilder
+    private var locationButton: some View {
+        MyLocationButton {
+            moveToUserLocation = true
+        }
+    }
 }
+
 
 #Preview {
     MapView()

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -11,6 +11,13 @@ import Domain
 
 public struct RecordDetailBottomSheet: View {
     @StateObject private var viewModel: RecordDetailViewModel
+    
+    // 1) 포커스 상태 열거형
+    private enum Field { case title }
+    
+    // 2) 부모 레벨 @FocusState
+    @FocusState private var focusedField: Field?
+    
     @State private var currentDetent: PresentationDetent = .fraction(0.45)
     
     private var isExpanded: Bool {
@@ -43,15 +50,24 @@ public struct RecordDetailBottomSheet: View {
                 .frame(minHeight: geometry.size.height)
             }
             .onTapGesture {
-                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                focusedField = nil
             }
         }
         .presentationDetents([.fraction(0.45), .large], selection: $currentDetent)
         .presentationDragIndicator(.visible)
         .ignoresSafeArea(.keyboard, edges: .bottom)
+        .onChange(of: viewModel.isEditing) { _, isNowEditing in
+            if isNowEditing {
+                DispatchQueue.main.async {
+                    focusedField = .title
+                }
+            } else {
+                focusedField = nil
+            }
+        }
         .onChange(of: currentDetent) { _, newDetent in
             guard newDetent != .large, viewModel.isEditing else { return }
-                viewModel.saveButtonTapped()
+            viewModel.saveButtonTapped()
         }
     }
     
@@ -75,6 +91,7 @@ public struct RecordDetailBottomSheet: View {
                     isEditing: viewModel.isEditing,
                     date: detail.date
                 )
+                .focused($focusedField, equals: .title)
             }
             .padding(.horizontal, 20)
         }
@@ -138,83 +155,73 @@ public struct RecordDetailBottomSheet: View {
         let isEditing: Bool
         let date: String
         
-        @FocusState private var isTitleFieldFocused: Bool
-        
         var body: some View {
-            VStack(spacing: 4) {
-                HStack(spacing: 0) {
+            VStack(spacing:4) {
+                HStack(spacing:0) {
                     if isEditing {
-                        ZStack(alignment: .center) {
+                        ZStack(alignment:.center) {
                             if title.isEmpty {
                                 Text(originalTitle)
-                                    .font(.system(size: 20, weight: .semibold))
-                                    .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15).opacity(0.5))
+                                    .font(.system(size:20, weight:.semibold))
+                                    .foregroundColor(.gray.opacity(0.5))
                             }
                             TextField("", text: $title)
-                                .font(.system(size: 20, weight: .semibold))
+                                .font(.system(size:20, weight:.semibold))
                                 .multilineTextAlignment(.center)
-                                .focused($isTitleFieldFocused)
                         }
                     } else {
                         Text(title)
-                            .font(.system(size: 20, weight: .semibold))
+                            .font(.system(size:20, weight:.semibold))
                     }
                 }
-                .foregroundColor(Color(red: 0.1, green: 0.12, blue: 0.15))
+                .foregroundColor(Color(red:0.1, green:0.12, blue:0.15))
                 
                 Text(date)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(Color(red: 0.57, green: 0.63, blue: 0.71))
+                    .font(.system(size:14, weight:.semibold))
+                    .foregroundColor(Color(red:0.57, green:0.63, blue:0.71))
             }
-            .onChange(of: isEditing) { _, isNowEditing in
-                if isNowEditing {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        isTitleFieldFocused = true
-                    }
+        }
+    }
+    
+    private struct EditButtonView: View {
+        let onEdit: () -> Void
+        let onDelete: () -> Void
+        
+        var body: some View {
+            Menu {
+                Button("기록 수정", action: onEdit)
+                Button(role: .destructive, action: onDelete) {
+                    Text("삭제")
                 }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(width: 32, height: 32)
+                    .background(Color(red: 0.45, green: 0.51, blue: 0.59).opacity(0.16))
+                    .foregroundColor(Color(red: 0.45, green: 0.51, blue: 0.59))
+                    .cornerRadius(99)
             }
         }
     }
-}
-
-private struct EditButtonView: View {
-    let onEdit: () -> Void
-    let onDelete: () -> Void
-
-    var body: some View {
-        Menu {
-            Button("기록 수정", action: onEdit)
-            Button(role: .destructive, action: onDelete) {
-                Text("삭제")
+    
+    private struct SaveButtonView: View {
+        let isDisabled: Bool
+        let action: () -> Void
+        
+        var body: some View {
+            Button(action: action) {
+                Text("수정 완료")
+                    .font(.headline.bold())
+                    .foregroundColor(.white)
+                    .frame(height: 52)
+                    .frame(maxWidth: .infinity)
+                    .background(isDisabled ? Color.gray : Color(red: 0.43, green: 0.65, blue: 0.96))
+                    .cornerRadius(12)
             }
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: 14, weight: .semibold))
-                .frame(width: 32, height: 32)
-                .background(Color(red: 0.45, green: 0.51, blue: 0.59).opacity(0.16))
-                .foregroundColor(Color(red: 0.45, green: 0.51, blue: 0.59))
-                .cornerRadius(99)
+            .disabled(isDisabled)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
         }
-    }
-}
-
-private struct SaveButtonView: View {
-    let isDisabled: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text("수정 완료")
-                .font(.headline.bold())
-                .foregroundColor(.white)
-                .frame(height: 52)
-                .frame(maxWidth: .infinity)
-                .background(isDisabled ? Color.gray : Color(red: 0.43, green: 0.65, blue: 0.96))
-                .cornerRadius(12)
-        }
-        .disabled(isDisabled)
-        .padding(.horizontal, 20)
-        .padding(.bottom, 20)
     }
 }
 

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -42,6 +42,9 @@ public struct RecordDetailBottomSheet: View {
                 .padding(.top, 34)
                 .frame(minHeight: geometry.size.height)
             }
+            .onTapGesture {
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+            }
         }
         .presentationDetents([.fraction(0.45), .large], selection: $currentDetent)
         .presentationDragIndicator(.visible)

--- a/Packages/Features/Sources/Features/Shared/Router/NavigationViewModel.swift
+++ b/Packages/Features/Sources/Features/Shared/Router/NavigationViewModel.swift
@@ -14,6 +14,10 @@ public final class NavigationViewModel: ObservableObject {
     public func push(_ route: AppRoute) {
         path.append(route)
     }
+    
+    public func pop() {
+        path.removeLast()
+    }
 
     public func reset() { path = .init() }
 

--- a/Packages/Features/Sources/Features/Shared/Router/NavigationViewModel.swift
+++ b/Packages/Features/Sources/Features/Shared/Router/NavigationViewModel.swift
@@ -16,6 +16,7 @@ public final class NavigationViewModel: ObservableObject {
     }
     
     public func pop() {
+        guard !path.isEmpty else { return }
         path.removeLast()
     }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #125 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- MapView 상단에 백버튼 추가 및 위치/스타일 정비
- 기존 ‘내 위치’ 버튼을 디자인 시스템(DSButton) 컴포넌트로 교체
- MKMapView 위에서 버튼 터치가 막히던 문제를 ZStack 계층 구조 재정비로 해결 (UI 레이어 분리)
- 버튼의 터치 영역을 확장하여 접근성 개선
- isEditing 상태일 때 외부 탭 시 키보드 자동 해제 처리 추가

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 지도 위 모든 버튼이 정상 동작하는지 확인
- [x] 백버튼 클릭 시 nav.pop 되는지 확인
- [x] 키보드 활성 상태에서 외부 탭 시 정상적으로 내려가는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- MapView.swift 내 ZStack 구조와 버튼 배치
- DSButton 컴포넌트로 교체된 내 위치 버튼
- RecordDetailBottomSheet .onChange로 UIResponder 호출하는 로직