### PR TITLE
♻️ Refactor: #129 앨범 기능 ViewModel 분리 및 바인딩 구조 개선

### DIFF
--- a/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
+++ b/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
@@ -91,13 +91,17 @@ public class BottomSheetCoordinator: ObservableObject {
     ) {
         print("📱 showSaveSheet 호출됨: \(info.flower.name)")
 
+        let CustomAlbumVM = CustomAlbumViewModel()
+        
         let viewModel = RecordSaveSheetViewModel(
             info: info,
+            albumViewModel: CustomAlbumVM,
             onSave: { [weak self] payload in
                 onSave(payload)
                 self?.dismissSheet()
             }
         )
+        
         self.saveSheetViewModel = viewModel
         self.onCancelPlacement = onCancel
         self.activeSheet = .saveSheet

--- a/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinatorDelegate.swift
+++ b/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinatorDelegate.swift
@@ -15,14 +15,14 @@ protocol BottomSheetCoordinatorDelegate: AnyObject {
 // MARK: - SwiftUI ViewModifier for Bottom Sheets
 struct BottomSheetCoordinatorModifier: ViewModifier {
     @ObservedObject var coordinator: BottomSheetCoordinator
-
+    
     func body(content: Content) -> some View {
         content
             .sheet(item: $coordinator.activeSheet) { sheetType in
                 sheetView(for: sheetType)
             }
     }
-
+    
     @ViewBuilder
     private func sheetView(for sheetType: BottomSheetType) -> some View {
         switch sheetType {
@@ -30,12 +30,12 @@ struct BottomSheetCoordinatorModifier: ViewModifier {
             FlowerSelectionBottomSheet(
                 viewModel: coordinator.flowerSelectionViewModel
             )
-
+            
         case .recordDetail:
             if let viewModel = coordinator.recordDetailViewModel {
                 RecordDetailBottomSheet(viewModel: viewModel)
             }
-
+            
         case .saveSheet:
             if let viewModel = coordinator.saveSheetViewModel {
                 RecordSaveSheetView(
@@ -51,7 +51,7 @@ struct BottomSheetCoordinatorModifier: ViewModifier {
 
 extension View {
     func bottomSheetCoordinator(coordinator: BottomSheetCoordinator)
-        -> some View
+    -> some View
     {
         modifier(BottomSheetCoordinatorModifier(coordinator: coordinator))
     }

--- a/Packages/Features/Sources/Features/CustomAlbum/AlbumGridItemView.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/AlbumGridItemView.swift
@@ -12,7 +12,7 @@ struct AlbumGridItemView: View {
     let asset: PHAsset
     let isSelected: Bool
     let selectedIndex: Int?
-    let viewModel: RecordSaveSheetViewModel
+    let viewModel: CustomAlbumViewModel
     let cellSize: CGFloat
 
     @State private var image: UIImage?

--- a/Packages/Features/Sources/Features/CustomAlbum/AlbumGridItemView.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/AlbumGridItemView.swift
@@ -16,6 +16,16 @@ struct AlbumGridItemView: View {
     let cellSize: CGFloat
 
     @State private var image: UIImage?
+    
+    init(asset: PHAsset, isSelected: Bool, selectedIndex: Int?, viewModel: CustomAlbumViewModel, cellSize: CGFloat) {
+        self.asset = asset
+        self.isSelected = isSelected
+        self.selectedIndex = selectedIndex
+        self.viewModel = viewModel
+        self.cellSize = cellSize
+        // State 변수를 ViewModel의 캐시 값으로 초기화합니다.
+        _image = State(initialValue: viewModel.getCachedImage(for: asset))
+    }
 
     var body: some View {
         ZStack {
@@ -32,10 +42,11 @@ struct AlbumGridItemView: View {
         .contentShape(Rectangle())
         .overlay(selectionOverlay)
         .onAppear {
-            Task {
-                // thumbnailSize를 cellSize에 맞춰 요청하여 화질 최적화
-                let thumbnailSize = CGSize(width: cellSize * UIScreen.main.scale, height: cellSize * UIScreen.main.scale)
-                self.image = await viewModel.fetchImage(for: asset, size: thumbnailSize)
+            if image == nil {
+                Task {
+                    let thumbnailSize = CGSize(width: cellSize * UIScreen.main.scale, height: cellSize * UIScreen.main.scale)
+                    self.image = await viewModel.fetchImage(for: asset, size: thumbnailSize)
+                }
             }
         }
 

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumView.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumView.swift
@@ -5,7 +5,7 @@ struct CustomAlbumView: View {
     @ObservedObject var viewModel: CustomAlbumViewModel
     @Environment(\.dismiss) private var dismiss
     
-    @State private var showLimitAlert = false  // ← 추가
+    @State private var showLimitAlert = false
     
     private let columns = 3
     private let spacing: CGFloat = 2

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumView.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Photos
 
 struct CustomAlbumView: View {
-    @ObservedObject var viewModel: RecordSaveSheetViewModel
+    @ObservedObject var viewModel: CustomAlbumViewModel
     @Environment(\.dismiss) private var dismiss
     
     @State private var showLimitAlert = false  // ← 추가
@@ -76,7 +76,7 @@ struct CustomAlbumView: View {
                 
                 if !viewModel.selectedAssets.isEmpty {
                     Button(action: {
-                        viewModel.finalizeAssetSelection()
+                        viewModel.finalizeSelection()
                         dismiss()
                     }) {
                         Text("\(viewModel.selectedAssets.count) 선택")

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
@@ -21,6 +21,8 @@ public final class CustomAlbumViewModel: ObservableObject {
     @Published var isLoading = false
     
     private let cachingImageManager = PHCachingImageManager()
+    private var imageCache: [String: UIImage] = [:]
+    
     let maxImageCount = 4
     
     let selectionDidFinishPublisher = PassthroughSubject<[PHAsset], Never>()
@@ -28,6 +30,10 @@ public final class CustomAlbumViewModel: ObservableObject {
     public init() {
         fetchInitialRecentAssets()
     }
+    
+    public func getCachedImage(for asset: PHAsset) -> UIImage? {
+         return imageCache[asset.localIdentifier]
+     }
     
     func fetchInitialRecentAssets() {
         isLoading = true
@@ -79,7 +85,7 @@ public final class CustomAlbumViewModel: ObservableObject {
     }
     
     func prepareForAllPhotos() {
-        guard allPhotoAssetsResult == nil else { return }  // 이미 로드했으면 다시 재로드 X
+        guard allPhotoAssetsResult == nil else { return }
 
         checkPermission { [weak self] hasPermission in
             guard let self = self, hasPermission else { return }
@@ -96,21 +102,34 @@ public final class CustomAlbumViewModel: ObservableObject {
     }
     
     public func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
-        let options = PHImageRequestOptions()
-        options.deliveryMode = .highQualityFormat
-        options.isNetworkAccessAllowed = true
-
-        return await withCheckedContinuation { continuation in
-            cachingImageManager.requestImage(
-                for: asset,
-                targetSize: size,
-                contentMode: .aspectFill,
-                options: options
-            ) { image, _ in
-                continuation.resume(returning: image)
+            // 캐시에 이미지가 있으면 즉시 반환합니다.
+            if let cachedImage = imageCache[asset.localIdentifier] {
+                return cachedImage
             }
+            
+            // 캐시에 없으면 PHCachingImageManager를 통해 이미지를 요청합니다.
+            let options = PHImageRequestOptions()
+            options.deliveryMode = .highQualityFormat
+            options.isNetworkAccessAllowed = true
+
+            let image = await withCheckedContinuation { continuation in
+                cachingImageManager.requestImage(
+                    for: asset,
+                    targetSize: size,
+                    contentMode: .aspectFill,
+                    options: options
+                ) { image, _ in
+                    continuation.resume(returning: image)
+                }
+            }
+            
+            // 로드된 이미지를 캐시에 저장합니다.
+            if let loadedImage = image {
+                imageCache[asset.localIdentifier] = loadedImage
+            }
+            
+            return image
         }
-    }
     
     private func checkPermission(completion: @escaping (Bool) -> Void) {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  CustomAlbumViewModel.swift
 //  Features
 //
 //  Created by Henry on 7/28/25.

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
@@ -1,0 +1,140 @@
+//
+//  File.swift
+//  Features
+//
+//  Created by Henry on 7/28/25.
+//
+
+import Combine
+import Photos
+import SwiftUI
+
+@MainActor
+public final class CustomAlbumViewModel: ObservableObject {
+    
+    @Published var recentPhotoAssets: [PHAsset] = []
+    @Published var allPhotoAssetsResult: PHFetchResult<PHAsset>?
+    
+    @Published var selectedAssets: [PHAsset] = []
+    
+    @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
+    @Published var isLoading = false
+    
+    private let cachingImageManager = PHCachingImageManager()
+    let maxImageCount = 4
+    
+    let selectionDidFinishPublisher = PassthroughSubject<[PHAsset], Never>()
+    
+    public init() {
+        fetchInitialRecentAssets()
+    }
+    
+    func fetchInitialRecentAssets() {
+        isLoading = true
+        checkPermission { [weak self] hasPermission in
+            guard let self = self, hasPermission else {
+                DispatchQueue.main.async { self?.isLoading = false }
+                return
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                let fetchOptions = PHFetchOptions()
+                fetchOptions.sortDescriptors = [
+                    NSSortDescriptor(key: "creationDate", ascending: false)
+                ]
+                fetchOptions.fetchLimit = 20
+
+                let fetchResult = PHAsset.fetchAssets(
+                    with: .image,
+                    options: fetchOptions
+                )
+                var assets: [PHAsset] = []
+                fetchResult.enumerateObjects { asset, _, _ in
+                    assets.append(asset)
+                }
+
+                DispatchQueue.main.async {
+                    self.recentPhotoAssets = assets
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+    
+    // 커스텀 앨범에서 사진 선택/해제
+    func toggleAssetSelection(_ asset: PHAsset) {
+        if let index = selectedAssets.firstIndex(of: asset) {
+            selectedAssets.remove(at: index)
+        } else if selectedAssets.count < maxImageCount {
+            selectedAssets.append(asset)
+        }
+    }
+    
+    func finalizeSelection() {
+         selectionDidFinishPublisher.send(selectedAssets)
+     }
+    
+    func clearSelectedAssets() {
+        selectedAssets.removeAll()
+    }
+    
+    func prepareForAllPhotos() {
+        guard allPhotoAssetsResult == nil else { return }  // 이미 로드했으면 다시 재로드 X
+
+        checkPermission { [weak self] hasPermission in
+            guard let self = self, hasPermission else { return }
+
+            let opts = PHFetchOptions()
+            opts.sortDescriptors = [
+                NSSortDescriptor(key: "creationDate", ascending: false)
+            ]
+            self.allPhotoAssetsResult = PHAsset.fetchAssets(
+                with: .image,
+                options: opts
+            )
+        }
+    }
+    
+    public func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .highQualityFormat
+        options.isNetworkAccessAllowed = true
+
+        return await withCheckedContinuation { continuation in
+            cachingImageManager.requestImage(
+                for: asset,
+                targetSize: size,
+                contentMode: .aspectFill,
+                options: options
+            ) { image, _ in
+                continuation.resume(returning: image)
+            }
+        }
+    }
+    
+    private func checkPermission(completion: @escaping (Bool) -> Void) {
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        self.authorizationStatus = status
+
+        switch status {
+        case .authorized, .limited:
+            completion(true)
+        case .notDetermined:
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                DispatchQueue.main.async {
+                    self.authorizationStatus = newStatus
+                    completion(
+                        newStatus == .authorized || newStatus == .limited
+                    )
+                }
+            }
+        default:  // .denied, .restricted
+            completion(false)
+        }
+    }
+    
+    
+}
+
+
+

--- a/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
@@ -10,17 +10,17 @@ import PhotosUI
 
 struct ImageCarouselView: View {
     @ObservedObject var viewModel: RecordDetailViewModel
+    @StateObject private var albumViewModel = CustomAlbumViewModel()
     
     let isExpanded: Bool
     let isEditing: Bool
-    
-    @State private var isPickerPresented = false
-    @State private var selectedPhotoItems: [PhotosPickerItem] = []
     
     private let fullSize: CGFloat = 342
     private let halfSize: CGFloat = 150
     private let itemSpacing: CGFloat = 12
     private let maxImageCount = 4
+    
+    @State private var isCustomAlbumPresented = false
     
     // MARK: - Body
     
@@ -90,7 +90,8 @@ struct ImageCarouselView: View {
                 
                 if isEditing && images.count < maxImageCount {
                     AddPhotoButton(size: fullSize) {
-                        isPickerPresented = true
+                        albumViewModel.clearSelectedAssets()
+                        isCustomAlbumPresented = true
                     }
                 }
             }
@@ -99,15 +100,11 @@ struct ImageCarouselView: View {
         }
         .scrollTargetBehavior(.viewAligned)
         .frame(height: fullSize)
-        .photosPicker(
-            isPresented: $isPickerPresented,
-            selection: $selectedPhotoItems,
-            maxSelectionCount: maxImageCount - images.count,
-            matching: .images
-        )
-        .onChange(of: selectedPhotoItems) { _, newItems in
-            viewModel.addImages(from: newItems)
-            selectedPhotoItems.removeAll()
+        .sheet(isPresented: $isCustomAlbumPresented) {
+            CustomAlbumView(viewModel: albumViewModel)
+        }
+        .onAppear {
+            viewModel.subscribeToAlbumEvents(CustomAlbumViewModel: albumViewModel)
         }
     }
 }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -18,9 +18,12 @@ public final class RecordDetailViewModel: ObservableObject {
     // MARK: - Published Properties
     @Published var detail: RecordDetailUIModel?
     @Published var isEditing: Bool = false
+    @Published var isLoading: Bool = false
 
     // 수정 전 원본 데이터를 저장할 프로퍼티
     private var originalDetail: RecordDetailUIModel?
+    // Combine 구독 관리를 위한 cancellables
+    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Computed Properties
     public var isSaveButtonDisabled: Bool {
@@ -33,7 +36,7 @@ public final class RecordDetailViewModel: ObservableObject {
         }
         
         let isTitleChanged = detail.title != originalDetail.title
-        let areImagesChanged = detail.images != originalDetail.images
+        let areImagesChanged = detail.images.count != originalDetail.images.count
 
         if !isTitleChanged && !areImagesChanged {
             return true
@@ -150,6 +153,15 @@ public final class RecordDetailViewModel: ObservableObject {
         originalDetail = detail
         isEditing = true
     }
+    
+    func subscribeToAlbumEvents(CustomAlbumViewModel: CustomAlbumViewModel) {
+        CustomAlbumViewModel.selectionDidFinishPublisher
+            .sink { [weak self] selectedAssets in
+                // 앨범에서 선택 완료 신호를 받으면, 이미지 추가 로직 실행
+                self?.addImages(from: selectedAssets, using: CustomAlbumViewModel)
+            }
+            .store(in: &cancellables)
+    }
 
     func saveButtonTapped() {
         if detail?.title.isEmpty == true {
@@ -165,20 +177,31 @@ public final class RecordDetailViewModel: ObservableObject {
     func deleteButtonTapped() {
         print("삭제 버튼 탭됨")
     }
+    
+    public func subscribeToAlbumEvents(albumViewModel: CustomAlbumViewModel) {
+        albumViewModel.selectionDidFinishPublisher
+            .sink { [weak self] selectedAssets in
+                // 앨범에서 선택이 완료되면, 이미지 추가 로직을 실행합니다.
+                self?.addImages(from: selectedAssets, using: albumViewModel)
+            }
+            .store(in: &cancellables)
+    }
 
     // MARK: - Image Handling
 
-    func addImages(from items: [PhotosPickerItem]) {
+   func addImages(from assets: [PHAsset], using albumViewModel: CustomAlbumViewModel) {
+        guard detail != nil else { return }
+        
+        isLoading = true
         Task {
             var newImages: [UIImage] = []
-            for item in items {
-                if let data = try? await item.loadTransferable(type: Data.self),
-                    let image = UIImage(data: data)
-                {
+            for asset in assets {
+                if let image = await albumViewModel.fetchImage(for: asset, size: PHImageManagerMaximumSize) {
                     newImages.append(image)
                 }
             }
             detail?.images.append(contentsOf: newImages)
+            isLoading = false
         }
     }
 

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -153,15 +153,6 @@ public final class RecordDetailViewModel: ObservableObject {
         originalDetail = detail
         isEditing = true
     }
-    
-    func subscribeToAlbumEvents(CustomAlbumViewModel: CustomAlbumViewModel) {
-        CustomAlbumViewModel.selectionDidFinishPublisher
-            .sink { [weak self] selectedAssets in
-                // 앨범에서 선택 완료 신호를 받으면, 이미지 추가 로직 실행
-                self?.addImages(from: selectedAssets, using: CustomAlbumViewModel)
-            }
-            .store(in: &cancellables)
-    }
 
     func saveButtonTapped() {
         if detail?.title.isEmpty == true {

--- a/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
@@ -56,7 +56,6 @@ public struct PhotoSelectionView: View {
     @ViewBuilder
     private var photoLibraryButton: some View {
         Button(action: {
-            // CustomAlbumView 띄우기 전 전체 사진 호출
             viewModel.prepareForAllPhotos()
             showCustomAlbum = true
         }) {
@@ -70,7 +69,7 @@ public struct PhotoSelectionView: View {
             .background(.clear)
         }
         .fullScreenCover(isPresented: $showCustomAlbum) {
-            CustomAlbumView(viewModel: viewModel)
+            CustomAlbumView(viewModel: viewModel.albumViewModel)
         }
     }
 }

--- a/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
@@ -15,7 +15,7 @@ struct RecentPhotosView: View {
     
     var body: some View {
         VStack {
-            switch viewModel.authorizationStatus {
+            switch viewModel.albumViewModel.authorizationStatus {
             case .authorized, .limited:
                 authorizedView
             case .denied, .restricted:
@@ -30,7 +30,7 @@ struct RecentPhotosView: View {
     
     @ViewBuilder
     private var authorizedView: some View {
-        if viewModel.isLoading {
+        if viewModel.albumViewModel.isLoading {
             loadingView
         } else if viewModel.recentPhotoAssets.isEmpty {
             VStack {
@@ -46,11 +46,11 @@ struct RecentPhotosView: View {
                     ForEach(viewModel.recentPhotoAssets, id: \.self) { asset in
                         PhotoItemView(
                             asset: asset,
-                            isSelected: viewModel.selectedAssets.contains(asset),
-                            selectedIndex: viewModel.selectedAssets.firstIndex(of: asset),
-                            viewModel: viewModel
+                            isSelected: viewModel.albumViewModel.selectedAssets.contains(asset),
+                            selectedIndex: viewModel.albumViewModel.selectedAssets.firstIndex(of: asset),
+                            viewModel: viewModel.albumViewModel
                         ) {
-                            viewModel.toggleAssetSelection(asset)
+                            viewModel.handleRecentPhotoTap(for: asset)
                         }
                     }
                 }
@@ -89,7 +89,7 @@ private struct PhotoItemView: View {
     let asset: PHAsset
     let isSelected: Bool
     let selectedIndex: Int?
-    let viewModel: RecordSaveSheetViewModel
+    let viewModel: CustomAlbumViewModel
     let action: () -> Void
     
     @State private var image: UIImage?

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -6,52 +6,82 @@ import SwiftUI
 
 @MainActor
 public final class RecordSaveSheetViewModel: ObservableObject {
-
+    
     // MARK: - Properties
     @Published var flowerName: String
     @Published var flowerMeaning: String
     @Published var flowerImageName: String
     @Published var address: String
-
+    
     @Published var recentPhotoAssets: [PHAsset] = []
-    @Published var allPhotoAssetsResult: PHFetchResult<PHAsset>?
-
-    @Published var selectedAssets: [PHAsset] = []
     @Published var selectedImages: [UIImage] = []
-
     @Published var didSelectFromLibrary: Bool = false
-    @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
+    
     @Published var isLoading = false
-
-    private let cachingImageManager = PHCachingImageManager()
-    private let onSave: (FinalRecordPayload) -> Void
-
+    
+    let albumViewModel: CustomAlbumViewModel
+    
+    private var cancellables = Set<AnyCancellable>()
+    let onSave: (FinalRecordPayload) -> Void
+    
     public var isSaveButtonDisabled: Bool {
-        return selectedAssets.isEmpty
+        return selectedImages.isEmpty
     }
-
-    let maxImageCount = 4
-
+    
     // MARK: - Initialization
     public init(
         info: RecordSaveSheetInfo,
+        albumViewModel: CustomAlbumViewModel,
         onSave: @escaping (FinalRecordPayload) -> Void
     ) {
         self.flowerName = info.flower.name
         self.flowerMeaning = info.flower.floriography
         self.flowerImageName = info.flower.thumbnail
         self.address = info.address
+        self.albumViewModel = albumViewModel
         self.onSave = onSave
-
-        fetchInitialRecentAssets()
+        
+        bindAlbumViewModel()
     }
-
+    
+    // MARK: - Binding
+    
+    private func bindAlbumViewModel() {
+        // 자식 ViewModel의 변화를 감지하여 View를 갱신
+        albumViewModel.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+        
+        // 최근 사진 목록 동기화
+        albumViewModel.$recentPhotoAssets
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.recentPhotoAssets, on: self)
+            .store(in: &cancellables)
+        
+        // 전체 앨범에서 '완료'를 눌렀을 때의 이벤트 구독
+        albumViewModel.selectionDidFinishPublisher
+            .sink { [weak self] selectedAssets in
+                // View 전환이 필요한 경우
+                self?.processSelectedAssets(selectedAssets, shouldFinalizeSelection: true)
+            }
+            .store(in: &cancellables)
+    }
+    
     // MARK: - User Actions
-
-    func save() {
+    
+    /// RecentPhotosView에서 사진을 탭했을 때 호출될 메서드
+    public func handleRecentPhotoTap(for asset: PHAsset) {
+        albumViewModel.toggleAssetSelection(asset)
+        // View 전환이 필요 없는 경우
+        processSelectedAssets(albumViewModel.selectedAssets, shouldFinalizeSelection: false)
+    }
+    
+    public func save() {
         isLoading = true
         Task {
-            let images = await fetchSelectedImages()
+            let images = self.selectedImages
             var savedFileNames: [String] = []
             
             for image in images {
@@ -69,27 +99,13 @@ public final class RecordSaveSheetViewModel: ObservableObject {
             isLoading = false
         }
     }
-
-    private func fetchSelectedImages() async -> [UIImage] {
-        var images: [UIImage] = []
-        for asset in selectedAssets {
-            if let image = await fetchImage(
-                for: asset,
-                size: PHImageManagerMaximumSize
-            ) {
-                images.append(image)
-            }
-        }
-        return images
-    }
-
-    /// 커스텀 앨범에서 '완료'를 눌렀을 때 호출
-    func finalizeAssetSelection() {
+    
+    private func processSelectedAssets(_ assets: [PHAsset], shouldFinalizeSelection: Bool) {
         Task {
             self.isLoading = true
             var images: [UIImage] = []
-            for asset in selectedAssets {
-                if let image = await fetchImage(
+            for asset in assets {
+                if let image = await albumViewModel.fetchImage(
                     for: asset,
                     size: CGSize(width: 400, height: 400)
                 ) {
@@ -97,126 +113,34 @@ public final class RecordSaveSheetViewModel: ObservableObject {
                 }
             }
             self.selectedImages = images
-            self.didSelectFromLibrary = true
+            
+            if shouldFinalizeSelection {
+                self.didSelectFromLibrary = !images.isEmpty
+            }
+            
             self.isLoading = false
         }
     }
-
-    /// 최종 선택된 사진 그리드에서 이미�� 삭제
-    func removeSelectedImage(_ image: UIImage) {
+    
+    public func removeSelectedImage(_ image: UIImage) {
         if let index = selectedImages.firstIndex(of: image) {
             selectedImages.remove(at: index)
-            if selectedAssets.indices.contains(index) {
-                selectedAssets.remove(at: index)
+            albumViewModel.selectedAssets.remove(at: index)
+            if selectedImages.isEmpty {
+                didSelectFromLibrary = false
             }
         }
     }
-
-    /// 커스텀 앨범에서 사진 선택/해제
-    func toggleAssetSelection(_ asset: PHAsset) {
-        if let index = selectedAssets.firstIndex(of: asset) {
-            selectedAssets.remove(at: index)
-        } else if selectedAssets.count < maxImageCount {
-            selectedAssets.append(asset)
-        }
+    
+    // MARK: - Pass-through Methods to AlbumViewModel
+    
+    /// View의 요청을 AlbumViewModel에 전달하는 역할
+    public func prepareForAllPhotos() {
+        albumViewModel.prepareForAllPhotos()
     }
-
-    /// 선택된 모든 에셋 초기화
-    func clearSelectedAssets() {
-        selectedAssets.removeAll()
-        didSelectFromLibrary = false
-    }
-
-    // MARK: - Data Fetching
-
-    /// RecentPhotosView를 위해 최근 에셋 20개만 불러옵니다.
-    func fetchInitialRecentAssets() {
-        isLoading = true
-        checkPermission { [weak self] hasPermission in
-            guard let self = self, hasPermission else {
-                DispatchQueue.main.async { self?.isLoading = false }
-                return
-            }
-
-            DispatchQueue.global(qos: .userInitiated).async {
-                let fetchOptions = PHFetchOptions()
-                fetchOptions.sortDescriptors = [
-                    NSSortDescriptor(key: "creationDate", ascending: false)
-                ]
-                fetchOptions.fetchLimit = 20
-
-                let fetchResult = PHAsset.fetchAssets(
-                    with: .image,
-                    options: fetchOptions
-                )
-                var assets: [PHAsset] = []
-                fetchResult.enumerateObjects { asset, _, _ in
-                    assets.append(asset)
-                }
-
-                DispatchQueue.main.async {
-                    self.recentPhotoAssets = assets
-                    self.isLoading = false
-                }
-            }
-        }
-    }
-
-    func prepareForAllPhotos() {
-        guard allPhotoAssetsResult == nil else { return }  // 이미 로드했으면 다시 재로드 X
-
-        checkPermission { [weak self] hasPermission in
-            guard let self = self, hasPermission else { return }
-
-            let opts = PHFetchOptions()
-            opts.sortDescriptors = [
-                NSSortDescriptor(key: "creationDate", ascending: false)
-            ]
-            self.allPhotoAssetsResult = PHAsset.fetchAssets(
-                with: .image,
-                options: opts
-            )
-        }
-    }
-
-    /// 권한을 확인하고 요청하는 공통 헬퍼 메서드
-    private func checkPermission(completion: @escaping (Bool) -> Void) {
-        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        self.authorizationStatus = status
-
-        switch status {
-        case .authorized, .limited:
-            completion(true)
-        case .notDetermined:
-            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
-                DispatchQueue.main.async {
-                    self.authorizationStatus = newStatus
-                    completion(
-                        newStatus == .authorized || newStatus == .limited
-                    )
-                }
-            }
-        default:  // .denied, .restricted
-            completion(false)
-        }
-    }
-
-    /// 주어진 PHAsset으로 UIImage를 비동기적으로 불러옵니다 (캐싱 적용).
+    
     public func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
-        let options = PHImageRequestOptions()
-        options.deliveryMode = .highQualityFormat
-        options.isNetworkAccessAllowed = true
-
-        return await withCheckedContinuation { continuation in
-            cachingImageManager.requestImage(
-                for: asset,
-                targetSize: size,
-                contentMode: .aspectFill,
-                options: options
-            ) { image, _ in
-                continuation.resume(returning: image)
-            }
-        }
+        return await albumViewModel.fetchImage(for: asset, size: size)
     }
 }
 

--- a/Packages/Features/Sources/Features/RecordSave/SwiftUIView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/SwiftUIView.swift
@@ -51,12 +51,14 @@ public struct SwiftUIView: View {
                 }
             }
             .sheet(isPresented: $isShowingSaveSheet) {
+                let albumVM = CustomAlbumViewModel()
                 let viewModel = RecordSaveSheetViewModel(
                     info: RecordSaveSheetInfo(
                         flower: ARFlower(name: "Test Flower", modelName: "test", floriography: "Test", thumbnail: "test"),
                         location: .init(),
                         address: "Test Address"
                     ),
+                    albumViewModel: albumVM,
                     onSave: { finalRecord in
                         // 여기서는 실제 저장을 하지 않으므로 비워둡니다.
                         // 필요하다면 savedRecords에 추가하는 로직을 구현할 수 있습니다.


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #129 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- RecordSaveSheetViewModel에 있던 앨범 로직을 AlbumViewModel로 분리
- Combine Publisher를 활용해 선택 완료 이벤트를 상위 ViewModel에 전달
- 하위 뷰는 AlbumViewModel만 참조 → ViewModel 의존성 역전
- 상위 ViewModel이 objectWillChange를 통해 자식 변경사항을 반영

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 사진 선택 → 선택된 이미지 View에 반영됨 확인
- [x] SaveSheet, Detail 뷰 모두에서 앨범 선택 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 많은 파일이 수정됐습니다.. 
- 현재 RecordSaveSheetViewModel 내에 있는 Save Button의 로그는 잘 찍히는데, ARCameraViewModel 내에서는 
- handleSaveRecord 내에 statusMessage = "저장 실패: \(error.localizedDescription)"가 찍히네요.. 원인이 뭔지

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
