### PR TITLE
♻️ Refactor: #152 AR 배치 관련 UI 개선 및 안내 문구 수정

### DIFF
--- a/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
@@ -120,7 +120,12 @@ public struct ARCameraView: View {
                     distance: viewModel.raycastDistance
                 )
                 
+                
+               
+              
+                
                 Spacer()
+                
                 ARStatusView(message: viewModel.statusMessage)
                 ARBottomBarView(
                     mode: viewModel.cameraMode,
@@ -130,7 +135,8 @@ public struct ARCameraView: View {
                     onCancelPlacement: viewModel.cancelPlacement,
                     onConfirmPlacement: viewModel.confirmPlacement,
                     onRepositionPlacement: viewModel.repositionPlacement,
-                    onSave: viewModel.requestSave
+                    onSave: viewModel.requestSave,
+                    status: viewModel.raycastStatus
                 )
             }
             .padding()

--- a/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
@@ -11,9 +11,9 @@ public struct ARCameraView: View {
     @StateObject private var viewModel: ARCameraViewModel
     @StateObject private var permissionsManager = PermissionsManager()
     @Environment(\.dismiss) private var dismiss
-
+    
     @State private var showPermissionAlert = false
-
+    
     public init(
         location: CLLocation,
         factory: ARCameraViewModelFactory
@@ -27,7 +27,7 @@ public struct ARCameraView: View {
         )
         _viewModel = StateObject(wrappedValue: viewModel)
     }
-
+    
     public var body: some View {
         ZStack {
             if permissionsManager.status == .granted {
@@ -63,10 +63,10 @@ public struct ARCameraView: View {
         }
         .bottomSheetCoordinator(coordinator: viewModel.bottomSheetCoordinator)
     }
-
+    
     private func checkAndRequestPermissions() {
         permissionsManager.check()
-
+        
         switch permissionsManager.status {
         case .unknown:
             Task {
@@ -86,7 +86,7 @@ public struct ARCameraView: View {
             UIApplication.shared.open(url)
         }
     }
-
+    
     private var arContentView: some View {
         ZStack {
             if #available(iOS 18.0, *) {
@@ -95,7 +95,7 @@ public struct ARCameraView: View {
             } else {
                 // Fallback on earlier versions
             }
-
+            
             VStack {
                 ARTopBarView(
                     onClose: { dismiss() },
@@ -108,29 +108,30 @@ public struct ARCameraView: View {
                     heading: viewModel.currentHeading,
                     direction: viewModel.currentDirection
                 )
-                CameraPitchView(
-                               pitch: viewModel.currentPitch,
-                               direction: viewModel.currentPitchDirection
-                           )
                 
-                // RayCast 상태 표시 (추가)
-                                RaycastStatusView(
-                                    status: viewModel.raycastStatus,
-                                    distance: viewModel.raycastDistance
-                                )
+                CameraPitchView(
+                    pitch: viewModel.currentPitch,
+                    direction: viewModel.currentPitchDirection
+                )
+                
+                // RayCast 상태 표시
+                RaycastStatusView(
+                    status: viewModel.raycastStatus,
+                    distance: viewModel.raycastDistance
+                )
                 
                 Spacer()
                 ARStatusView(message: viewModel.statusMessage)
                 ARBottomBarView(
-                                mode: viewModel.cameraMode,
-                                isPlacementConfirmed: viewModel.isPlacementConfirmed,
-                                onSwitchToPlacement: viewModel.switchToPlacementMode,
-                                onSelectFlower: viewModel.showFlowerSelectionSheet,
-                                onCancelPlacement: viewModel.cancelPlacement,
-                                onConfirmPlacement: viewModel.confirmPlacement,
-                                onRepositionPlacement: viewModel.repositionPlacement,
-                                onSave: viewModel.requestSave
-                            )
+                    mode: viewModel.cameraMode,
+                    isPlacementConfirmed: viewModel.isPlacementConfirmed,
+                    onSwitchToPlacement: viewModel.switchToPlacementMode,
+                    onSelectFlower: viewModel.showFlowerSelectionSheet,
+                    onCancelPlacement: viewModel.cancelPlacement,
+                    onConfirmPlacement: viewModel.confirmPlacement,
+                    onRepositionPlacement: viewModel.repositionPlacement,
+                    onSave: viewModel.requestSave
+                )
             }
             .padding()
         }
@@ -141,13 +142,13 @@ public struct ARCameraView: View {
 @available(iOS 18.0, *)
 internal struct ARViewContainer: UIViewRepresentable {
     public let sceneManager: ARSceneManager
-
+    
     public func makeUIView(context: Context) -> ARView {
         let arView = ARView(frame: .zero)
         sceneManager.setup(arView: arView)
         return arView
     }
-
+    
     public func updateUIView(_ uiView: ARView, context: Context) {
         // ARView 업데이트가 필요한 경우 여기에 로직 추가
     }

--- a/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
@@ -225,7 +225,7 @@ public class ARCameraViewModel: NSObject, ObservableObject {
             placedAt: Date()
         )
         isPlacementConfirmed = true
-        statusMessage = "배치가 확정되었습니다. 저장 버튼을 눌러 기록을 저장하세요."
+        statusMessage = "다른 곳을 비쳐서 재배치 버튼을 탭하면\n다시 심을 수 있어요"
         print("🔥 confirmPlacement() 완료")
     }
 
@@ -239,7 +239,7 @@ public class ARCameraViewModel: NSObject, ObservableObject {
         )
         isPlacementConfirmed = false
         arSceneManager.startRepositioning()
-        statusMessage = "꽃을 다시 배치하세요."
+        statusMessage = "🔴 여기에 \(currentPlacement?.flower.name ?? "")를 심을까요?"
     }
 
     func requestSave() {

--- a/Packages/Features/Sources/Features/ARCamera/Components/ARBottomBarView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Components/ARBottomBarView.swift
@@ -7,6 +7,7 @@ import DesignSystem
 //
 import SwiftUI
 
+@available(iOS 18.0, *)
 struct ARBottomBarView: View {
     let mode: ARCameraMode
     let isPlacementConfirmed: Bool
@@ -16,6 +17,7 @@ struct ARBottomBarView: View {
     let onConfirmPlacement: () -> Void
     let onRepositionPlacement: () -> Void
     let onSave: () -> Void
+    let status: ARSceneManager.RaycastStatus
 
     var body: some View {
         switch mode {
@@ -43,6 +45,8 @@ struct ARBottomBarView: View {
                 ARBackWardButton(action: onRepositionPlacement)
             } else {
                 ARCheckButton(action: onConfirmPlacement)
+                    .disabled(!getStatus())
+                      .opacity(getStatus() ? 1.0 : 0.4) // 상태 표시를 위해 반투명 처리
             }
 
             if isPlacementConfirmed {
@@ -50,6 +54,19 @@ struct ARBottomBarView: View {
             } else {
                 Circle().fill(Color.clear).frame(width: 60, height: 60)
             }
+        }
+    }
+    
+    private func getStatus() -> Bool {
+        switch status {
+        case .idle:
+            return false
+        case .success:
+            return true
+        case .fallback:
+            return false
+        case .failed:
+            return true
         }
     }
 }

--- a/Packages/Features/Sources/Features/ARCamera/Components/ARBottomBarView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Components/ARBottomBarView.swift
@@ -32,7 +32,12 @@ struct ARBottomBarView: View {
 
     private var placementModeButtons: some View {
         HStack(spacing: 30) {
-            ARFlowerButton(action: onSelectFlower)
+            if !isPlacementConfirmed {
+                ARFlowerButton(action: onSelectFlower)
+            } else {
+                Circle().fill(Color.clear).frame(width: 60, height: 60)
+            }
+           
 
             if isPlacementConfirmed {
                 ARBackWardButton(action: onRepositionPlacement)

--- a/Packages/Features/Sources/Features/ARCamera/Components/ARStatusView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Components/ARStatusView.swift
@@ -17,6 +17,7 @@ struct ARStatusView: View {
             .cornerRadius(10)
             .padding(.bottom, 20)
             .animation(.easeInOut, value: message)
+            .multilineTextAlignment(.center)
     }
     
     private func formatMessage(_ message: String) -> some View {

--- a/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
+++ b/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
@@ -212,7 +212,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
     private func addLightingToFlower(_ flowerEntity: ModelEntity) {
         // 🌞 방향성 조명: 햇빛 역할
         let directionalLight = DirectionalLight()
-        directionalLight.light.intensity = 10000  // 더 강하게
+        directionalLight.light.intensity = 7000  //
         directionalLight.light.color = UIColor(red: 1.0, green: 0.96, blue: 0.85, alpha: 1.0) // 햇빛 느낌의 따뜻한 색
 
         // 햇빛이 약간 비스듬하게 비추는 느낌 (예: 남동쪽 방향에서)
@@ -220,7 +220,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
 
         // 🌤️ 부드러운 전체 조명: 그림자 어두움을 줄이기 위해 Ambient 느낌 추가
         let ambientLight = PointLight()
-        ambientLight.light.intensity = 5000
+        ambientLight.light.intensity = 3000
         ambientLight.light.color = UIColor(red: 1.0, green: 0.97, blue: 0.9, alpha: 1.0)
         ambientLight.light.attenuationRadius = 2.0
         ambientLight.position = [0, 0.5, 0]
@@ -229,14 +229,115 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         flowerEntity.addChild(directionalLight)
         flowerEntity.addChild(ambientLight)
     }
-
-    func confirmPlacement() {
+    
+    private func addNaturalSunlight(to flowerEntity: ModelEntity, cameraPosition: SIMD3<Float>) {
+        // 🌅 시간대별 햇빛 색상 (더 미묘하고 자연스럽게)
+        let sunlightColor = getSunlightColorForCurrentTime()
+        
+        // 🌞 주 햇빛: 부드럽고 자연스러운 방향성 조명
+        let mainSunlight = createMainSunlight(color: sunlightColor)
+        
+        // 🌤️ 하늘 산란광: 부드러운 전체 조명 (하늘에서 오는 간접광)
+        let skyLight = createSkyAmbientLight(color: sunlightColor)
+        
+    
+        
+        // 📐 카메라 위치 기반 보조 조명 (너무 어두운 부분 방지)
+        let fillLight = createCameraFillLight(cameraPosition: cameraPosition, flowerPosition: flowerEntity.position)
+        
+        // 조명들을 꽃에 추가
+        flowerEntity.addChild(mainSunlight)
+        flowerEntity.addChild(skyLight)
+        flowerEntity.addChild(fillLight)
+        
+        print("🌸 자연스러운 햇빛 조명 적용 완료")
+    }
+    
+    // MARK: - 시간대별 햇빛 색상
+    private func getSunlightColorForCurrentTime() -> UIColor {
+        let hour = Calendar.current.component(.hour, from: Date())
+        
+        switch hour {
+        case 6..<8:   // 새벽 - 차가운 푸른빛
+            return UIColor(red: 0.9, green: 0.95, blue: 1.0, alpha: 1.0)
+        case 8..<10:  // 아침 - 따뜻한 황금빛
+            return UIColor(red: 1.0, green: 0.94, blue: 0.8, alpha: 1.0)
+        case 10..<16: // 낮 - 자연스러운 흰색
+            return UIColor(red: 1.0, green: 0.98, blue: 0.95, alpha: 1.0)
+        case 16..<18: // 오후 - 따뜻한 오렌지
+            return UIColor(red: 1.0, green: 0.9, blue: 0.7, alpha: 1.0)
+        case 18..<20: // 저녁 - 붉은 노을
+            return UIColor(red: 1.0, green: 0.8, blue: 0.6, alpha: 1.0)
+        default:      // 밤 - 달빛 (차가운 푸른빛)
+            return UIColor(red: 0.7, green: 0.8, blue: 1.0, alpha: 1.0)
+        }
+    }
+    
+    // MARK: - 주 햇빛 (자연스러운 방향성 조명)
+    private func createMainSunlight(color: UIColor) -> DirectionalLight {
+        let sunlight = DirectionalLight()
+        
+        // 🌞 강도를 낮추고 더 자연스럽게
+        sunlight.light.intensity = 7000  // 기존 7000에서 대폭 감소
+        sunlight.light.color = color
+        
+        // ☀️ 현실적인 햇빛 각도 (45도 각도에서 약간 측면에서)
+        // 너무 직접적이지 않고 자연스러운 각도
+        let sunDirection = normalize(SIMD3<Float>(0.3, -0.8, -0.5))  // 더 부드러운 각도
+        
+        // 햇빛 방향 설정 (look(at:from:) 대신 transform 직접 설정)
+        var transform = Transform()
+        transform.rotation = simd_quatf(from: SIMD3<Float>(0, 0, -1), to: sunDirection)
+        sunlight.transform = transform
+        
+        return sunlight
+    }
+    
+    // MARK: - 하늘 산란광 (부드러운 전체 조명)
+    private func createSkyAmbientLight(color: UIColor) -> PointLight {
+        let skyLight = PointLight()
+        
+        // 🌤️ 하늘에서 오는 부드러운 간접광
+        skyLight.light.intensity = 3000
+        skyLight.light.color = UIColor(
+            red: color.cgColor.components?[0] ?? 1.0,
+            green: (color.cgColor.components?[1] ?? 1.0) + 0.05,  // 하늘빛 약간 추가
+            blue: (color.cgColor.components?[2] ?? 1.0) + 0.1,   // 파란빛 약간 추가
+            alpha: 1.0
+        )
+        
+        // 위쪽에서 넓게 퍼지는 조명
+        skyLight.light.attenuationRadius = 30.0  // 더 넓은 범위
+        skyLight.position = [0, 1.5, 0]  // 꽃 위쪽
+        
+        return skyLight
+    }
+    
+   
+    
+    // MARK: - 카메라 보조 조명 (자연스러운 fill light)
+    private func createCameraFillLight(cameraPosition: SIMD3<Float>, flowerPosition: SIMD3<Float>) -> PointLight {
+        let fillLight = PointLight()
+        
+        // 📷 카메라 쪽에서 오는 매우 약한 보조 조명 (너무 어두운 부분 방지)
+        fillLight.light.intensity = 3000  // 매우 약함
+        fillLight.light.color = UIColor(red: 1.0, green: 0.98, blue: 0.96, alpha: 1.0)  // 중성적인 색
+        fillLight.light.attenuationRadius = 2.0
+        
+        // 카메라와 꽃 사이의 중간 지점에 배치
+        let midPoint = (cameraPosition + flowerPosition) * 0.5
+        fillLight.position = [midPoint.x, midPoint.y + 0.2, midPoint.z]
+        
+        return fillLight
+    }
+    
+    // MARK: - 개선된 꽃 배치 시 조명 적용
+    func confirmPlacementWithNaturalLighting() {
         guard placementState.canConfirm,
               let arView = arView,
               let position = placementAnchor?.position,
               let currentFrame = arView.session.currentFrame else { return }
         
-        // 인디케이터 위치에 꽃 생성
         if let entity = placementState.entity {
             let flowerAnchor = AnchorEntity(world: position)
             let flowerClone = entity.clone(recursive: true)
@@ -248,25 +349,86 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             // 🌸 꽃 크기 조정
             let distanceVector = cameraPosition - flowerPosition
             let distance = simd_length(distanceVector)
+            let dynamicScale = max(0.3, min(0.5, 0.8 / distance))
+            flowerClone.transform.scale = SIMD3<Float>(dynamicScale, dynamicScale, dynamicScale)
+            
+            // 꽃 회전 설정
+            let directionToCamera = normalize(cameraPosition - flowerPosition)
+            let horizontalDirection = normalize(SIMD3<Float>(directionToCamera.x, 0, directionToCamera.z))
+            let angle = atan2(horizontalDirection.x, -horizontalDirection.z)
+            let rotation = simd_quatf(angle: angle, axis: SIMD3<Float>(0, 1, 0))
+            flowerClone.transform.rotation = rotation
+            
+            // 🌞 자연스러운 햇빛 조명 적용
+            addNaturalSunlight(to: flowerClone, cameraPosition: cameraPosition)
+            
+            flowerAnchor.addChild(flowerClone)
+            arView.scene.addAnchor(flowerAnchor)
+            
+            // 현재 꽃 앵커 추적
+            self.currentFlowerAnchor = flowerAnchor
+            
+            print("🌸 자연스러운 조명과 함께 꽃 배치 완료")
+        }
+        
+        placementState.confirm()
+        removePlacementAnchor()
+        onPlacementStateChanged?(placementState.status)
+    }
+    private func addSubtleWindEffect(to flowerEntity: ModelEntity) {
+        // 매우 미묘한 흔들림 효과
+        let swayAmount: Float = 0.02  // 2cm 정도의 미묘한 움직임
+        let swayDuration: Float = 3.0 + Float.random(in: -0.5...0.5)  // 랜덤한 주기
+        
+        // X축과 Z축으로 미묘하게 흔들리는 애니메이션
+        let swayTransform = Transform(
+            scale: SIMD3<Float>(1, 1, 1),
+            rotation: simd_quatf(angle: swayAmount, axis: SIMD3<Float>(1, 0, 1)),
+            translation: SIMD3<Float>(0, 0, 0)
+        )
+        
+        let swayAnimation = FromToByAnimation(
+            name: "windSway",
+            from: Transform.identity,
+            to: swayTransform,
+            duration: TimeInterval(swayDuration),
+            timing: .easeInOut,
+            isAdditive: true
+        )
+        
+        if let animationResource = try? AnimationResource.generate(with: swayAnimation) {
+            flowerEntity.playAnimation(animationResource.repeat())
+        }
+    }
+    
+    
+    func confirmPlacement() {
+        guard placementState.canConfirm,
+              let arView = arView,
+              let position = placementAnchor?.position,
+              let currentFrame = arView.session.currentFrame else { return }
+        
+        // 인디케이터 위치에 꽃 생성
+        if let entity = placementState.entity {
+            let flowerAnchor = AnchorEntity(world: position)
+            let flowerClone = entity.clone(recursive: true)
+            
+            // 🌸 카메라 위치 (크기 조정용)
+            let cameraPosition = extractPositionFromTransform(currentFrame.camera.transform)
+            let flowerPosition = position
+            
+            // 🌸 꽃 크기 조정
+            let distanceVector = cameraPosition - flowerPosition
+            let distance = simd_length(distanceVector)
             let dynamicScale = max(0.3, min(0.5, 0.8 / distance)) //꽃 크기 조정 가능
             flowerClone.transform.scale = SIMD3<Float>(dynamicScale, dynamicScale, dynamicScale)
             
-            // 꽃에서 카메라로의 방향 벡터 계산
-            let directionToCamera = normalize(cameraPosition - flowerPosition)
+            // 🧭 currentUserHeading을 기준으로 꽃 방향 설정
+            let flowerRotation = calculateFlowerRotationFromHeading()
+            flowerClone.transform.rotation = flowerRotation
             
-            // Y축 회전만 적용 (꽃이 기울어지지 않고 수평면에서만 회전)
-            let horizontalDirection = normalize(SIMD3<Float>(directionToCamera.x, 0, directionToCamera.z))
-            
-            // 기본 앞 방향 (0, 0, -1)에서 목표 방향으로의 회전 계산
-            let defaultForward = SIMD3<Float>(0, 0, -1)
-            let angle = atan2(horizontalDirection.x, -horizontalDirection.z)
-            
-            // Y축 회전만 적용 (수평 회전만)
-            let rotation = simd_quatf(angle: angle, axis: SIMD3<Float>(0, 1, 0))
-            
-            // 꽃 엔티티에 회전 적용
-            flowerClone.transform.rotation = rotation
-            addLightingToFlower(flowerClone)
+            addNaturalSunlight(to: flowerClone, cameraPosition: cameraPosition)
+            addSubtleWindEffect(to: flowerClone)
             
             flowerAnchor.addChild(flowerClone)
             arView.scene.addAnchor(flowerAnchor)
@@ -277,13 +439,64 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             // 배치된 좌표 정보 로그 출력
             logPlacementCoordinates(arPosition: position)
             
-            print("🌸 꽃이 카메라를 향하도록 회전 적용: \(String(format: "%.1f", angle * 180 / Float.pi))도")
-            print("🌸 꽃 크기 동적 조정: \(String(format: "%.1f", dynamicScale * 100))% (거리: \(String(format: "%.2f", distance))m - 멀어질수록 작아짐)")
+            print("🌸 꽃 크기 동적 조정: \(String(format: "%.1f", dynamicScale * 100))% (거리: \(String(format: "%.2f", distance))m)")
         }
         
         placementState.confirm()
         removePlacementAnchor() // 앵커 제거
         onPlacementStateChanged?(placementState.status)
+    }
+
+    // MARK: - 나침반 기준 꽃 방향 계산
+    private func calculateFlowerRotationFromHeading() -> simd_quatf {
+        guard let userHeading = currentUserHeading else {
+            print("⚠️ currentUserHeading이 nil입니다. 기본 방향 사용")
+            return simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0))
+        }
+        
+        // 🧭 사용자의 현재 나침반 방향 (자북 기준, 도 단위)
+        let userHeadingDegrees = userHeading.trueHeading
+        print("🧭 현재 사용자 헤딩: \(String(format: "%.1f", userHeadingDegrees))도")
+        
+        // 🌸 꽃이 바라볼 방향 설정 (사용자와 같은 방향 또는 반대 방향)
+        let flowerTargetHeading = getFlowerTargetHeading(userHeading: userHeadingDegrees)
+        print("🌸 꽃 목표 방향: \(String(format: "%.1f", flowerTargetHeading))도")
+        
+        // 🔄 도 단위를 라디안으로 변환
+        let flowerHeadingRadians = Float(flowerTargetHeading * .pi / 180.0)
+        
+        // 🎯 ARKit 좌표계에서의 회전 계산
+        // ARKit: Z축이 뒤쪽, X축이 오른쪽
+        // 나침반: 0도가 북쪽, 시계방향으로 증가
+        
+        // 나침반 방향을 ARKit 좌표계로 변환
+        // 나침반 0도(북쪽) = ARKit에서 -Z 방향
+        // 나침반 90도(동쪽) = ARKit에서 +X 방향
+        let arKitRotationAngle = -flowerHeadingRadians + Float.pi / 2
+        
+        // Y축 중심 회전 (수평면에서만 회전)
+        let rotation = simd_quatf(angle: arKitRotationAngle, axis: SIMD3<Float>(0, 1, 0))
+        
+        return rotation
+    }
+
+    // MARK: - 꽃이 바라볼 목표 방향 결정
+    private func getFlowerTargetHeading(userHeading: Double) -> Double {
+        // 옵션 1: 사용자와 같은 방향 (사용자가 보는 방향)
+        let sameDirection = userHeading
+        
+        // 옵션 2: 사용자 반대 방향 (사용자를 바라보는 방향)
+        let oppositeDirection = userHeading >= 180 ? userHeading - 180 : userHeading + 180
+        
+        // 옵션 3: 고정 방향 (예: 항상 북쪽)
+        let fixedDirection = 0.0  // 북쪽
+        
+        // 🌸 원하는 설정 선택 (현재는 사용자와 같은 방향)
+        return sameDirection
+        
+        // 다른 옵션을 사용하려면 위의 return을 주석처리하고 아래 중 하나 선택:
+         return oppositeDirection  // 사용자를 바라보게 하려면
+        // return fixedDirection     // 항상 북쪽을 바라보게 하려면
     }
     
     /// 현재 배치된 위치의 GPS 좌표를 반환합니다.

--- a/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
+++ b/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
@@ -4,6 +4,7 @@ import CoreLocation
 import RealityKit
 import SwiftUI
 import UIKit
+import simd
 
 @available(iOS 18.0, *)
 @MainActor
@@ -198,12 +199,41 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
     func confirmPlacement() {
         guard placementState.canConfirm,
               let arView = arView,
-              let position = placementAnchor?.position else { return }
+              let position = placementAnchor?.position,
+              let currentFrame = arView.session.currentFrame else { return }
         
         // 인디케이터 위치에 꽃 생성
         if let entity = placementState.entity {
             let flowerAnchor = AnchorEntity(world: position)
-            flowerAnchor.addChild(entity.clone(recursive: true))
+            let flowerClone = entity.clone(recursive: true)
+            
+            // 🌸 카메라를 향하도록 꽃 회전 설정
+            let cameraPosition = extractPositionFromTransform(currentFrame.camera.transform)
+            let flowerPosition = position
+            
+            // 🌸 꽃 크기 조정
+            let distanceVector = cameraPosition - flowerPosition
+            let distance = simd_length(distanceVector)
+            let dynamicScale = max(0.3, min(0.5, 0.8 / distance)) //꽃 크기 조정 가능
+            flowerClone.transform.scale = SIMD3<Float>(dynamicScale, dynamicScale, dynamicScale)
+            
+            // 꽃에서 카메라로의 방향 벡터 계산
+            let directionToCamera = normalize(cameraPosition - flowerPosition)
+            
+            // Y축 회전만 적용 (꽃이 기울어지지 않고 수평면에서만 회전)
+            let horizontalDirection = normalize(SIMD3<Float>(directionToCamera.x, 0, directionToCamera.z))
+            
+            // 기본 앞 방향 (0, 0, -1)에서 목표 방향으로의 회전 계산
+            let defaultForward = SIMD3<Float>(0, 0, -1)
+            let angle = atan2(horizontalDirection.x, -horizontalDirection.z)
+            
+            // Y축 회전만 적용 (수평 회전만)
+            let rotation = simd_quatf(angle: angle, axis: SIMD3<Float>(0, 1, 0))
+            
+            // 꽃 엔티티에 회전 적용
+            flowerClone.transform.rotation = rotation
+            
+            flowerAnchor.addChild(flowerClone)
             arView.scene.addAnchor(flowerAnchor)
             
             // 현재 꽃 앵커 추적 (재배치 시 제거용)
@@ -211,6 +241,9 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             
             // 배치된 좌표 정보 로그 출력
             logPlacementCoordinates(arPosition: position)
+            
+            print("🌸 꽃이 카메라를 향하도록 회전 적용: \(String(format: "%.1f", angle * 180 / Float.pi))도")
+            print("🌸 꽃 크기 동적 조정: \(String(format: "%.1f", dynamicScale * 100))% (거리: \(String(format: "%.2f", distance))m - 멀어질수록 작아짐)")
         }
         
         placementState.confirm()
@@ -753,6 +786,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         removePlacementAnchor()
         onPlacementStateChanged?(placementState.status)
     }
+    
     // 카메라 위치 헬퍼 메서드 추가
     private func getCameraPosition() -> SIMD3<Float> {
         guard let arView = arView,

--- a/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
+++ b/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
@@ -41,8 +41,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
     nonisolated(unsafe) private var lastRaycastTime: TimeInterval = 0
     private let raycastInterval: TimeInterval = 1.0 / 20.0 // 20 FPS로 레이캐스트 주기 설정
     nonisolated(unsafe) private var targetPosition: SIMD3<Float>?
-    
-    
+
     // MARK: - Callbacks
     var onRecordTapped: ((ARRecordModel) -> Void)?
     var onPlacementStateChanged: ((ARPlacementState.Status) -> Void)?
@@ -77,7 +76,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         let velocity = distance / Float(deltaTime)
         
         // 빠른 움직임 감지 (초당 30cm 이상 이동)
-        return velocity > 0.3
+        return velocity > 0.1
     }
 
     
@@ -514,7 +513,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         if let result = estimatedResults.first {
             let position = extractPositionFromTransform(result.worldTransform)
             let distance = length(position - getCameraPosition())
-            raycastStatus = .success(distance: distance)
+            raycastStatus = .fallback(distance: distance)
             lastRaycastDistance = distance
             return position
         }
@@ -529,7 +528,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         if let result = anyPlaneResults.first {
             let position = extractPositionFromTransform(result.worldTransform)
             let distance = length(position - getCameraPosition())
-            raycastStatus = .success(distance: distance)
+            raycastStatus = .fallback(distance: distance)
             lastRaycastDistance = distance
             return position
         }
@@ -660,14 +659,6 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             return
         }
         
-        // 더 눈에 잘 띄는 인디케이터 생성 (펄스 애니메이션 추가)
-        let radius: Float = 0.10
-        let indicatorMesh = MeshResource.generateSphere(radius: radius)
-        
-        var material = UnlitMaterial(color: .red) // UnlitMaterial로 변경하여 더 선명하게
-        
-        let indicator = ModelEntity(mesh: indicatorMesh, materials: [material])
-        
         // 🎭 펄스 애니메이션 추가
         let scaleUp = Transform(scale: SIMD3<Float>(1.2, 1.2, 1.2), rotation: simd_quatf(), translation: SIMD3<Float>(0, 0, 0))
         let scaleDown = Transform(scale: SIMD3<Float>(0.8, 0.8, 0.8), rotation: simd_quatf(), translation: SIMD3<Float>(0, 0, 0))
@@ -686,18 +677,33 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         
         // 그림자 효과
         let shadowMesh = MeshResource.generatePlane(width: 0.25, depth: 0.25,cornerRadius: 50)
-        var shadowMaterial = UnlitMaterial(color: UIColor.red.withAlphaComponent(0.05))
+       
+  
+
+        var shadowMaterial = UnlitMaterial()
+        shadowMaterial.baseColor = MaterialColorParameter.color(UIColor.red.withAlphaComponent(0.3))
         
+     
+   
         let shadow = ModelEntity(mesh: shadowMesh, materials: [shadowMaterial])
         shadow.position.y = -0.12
         
+        let dashedCircle = makeDashedCircle(
+            radius: 0.125,              // 바깥 원의 반지름
+            dotCount: 24,               // 점 개수 (숫자가 작을수록 간격 넓음)
+            dotSize: 0.005,             // 점 하나의 크기 (반지름)
+            color: UIColor.white.withAlphaComponent(0.8) // 점 색상 및 투명도
+        )
+        dashedCircle.position.y = -0.12
+        
         if let resource = animationResource {
             shadow.playAnimation(resource.repeat())
+            dashedCircle.playAnimation(resource.repeat())
         }
         
         // 앵커 생성 및 설정
         let indicatorAnchor = AnchorEntity(world: finalPosition)
-//        indicatorAnchor.addChild(indicator)
+        indicatorAnchor.addChild(dashedCircle)
         indicatorAnchor.addChild(shadow)
         arView.scene.addAnchor(indicatorAnchor)
         
@@ -705,6 +711,29 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         
         print("✅ 개선된 인디케이터 생성: [\(String(format: "%.3f", finalPosition.x)), \(String(format: "%.3f", finalPosition.y)), \(String(format: "%.3f", finalPosition.z))]")
     }
+    
+    func makeDashedCircle(radius: Float, dotCount: Int, dotSize: Float, color: UIColor) -> Entity {
+        let parent = Entity()
+
+        for i in 0..<dotCount {
+            let angle = (Float(i) / Float(dotCount)) * 2 * Float.pi
+            let x = cos(angle) * radius
+            let z = sin(angle) * radius
+
+            let dotMesh = MeshResource.generateSphere(radius: dotSize)
+            var dotMaterial = UnlitMaterial()
+            dotMaterial.baseColor = .color(color)
+
+            let dotEntity = ModelEntity(mesh: dotMesh, materials: [dotMaterial])
+            dotEntity.position = [x, 0, z]
+
+            parent.addChild(dotEntity)
+        }
+
+        return parent
+    }
+    
+    
     private func removePlacementAnchor() {
         guard let arView = arView,
               let anchor = placementAnchor else { return }

--- a/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
+++ b/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
@@ -42,7 +42,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
     nonisolated(unsafe) private var lastRaycastTime: TimeInterval = 0
     private let raycastInterval: TimeInterval = 1.0 / 20.0 // 20 FPS로 레이캐스트 주기 설정
     nonisolated(unsafe) private var targetPosition: SIMD3<Float>?
-
+    
     // MARK: - Callbacks
     var onRecordTapped: ((ARRecordModel) -> Void)?
     var onPlacementStateChanged: ((ARPlacementState.Status) -> Void)?
@@ -57,7 +57,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
     // 🆕 빠른 카메라 움직임 감지
     private var lastCameraPosition: SIMD3<Float>?
     private var lastUpdateTime: TimeInterval = 0
-
+    
     private func shouldForceUpdate(currentCameraPosition: SIMD3<Float>) -> Bool {
         let currentTime = CACurrentMediaTime()
         
@@ -79,7 +79,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         // 빠른 움직임 감지 (초당 30cm 이상 이동)
         return velocity > 0.1
     }
-
+    
     
     enum RaycastStatus {
         case idle
@@ -214,17 +214,17 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         let directionalLight = DirectionalLight()
         directionalLight.light.intensity = 7000  //
         directionalLight.light.color = UIColor(red: 1.0, green: 0.96, blue: 0.85, alpha: 1.0) // 햇빛 느낌의 따뜻한 색
-
+        
         // 햇빛이 약간 비스듬하게 비추는 느낌 (예: 남동쪽 방향에서)
         directionalLight.look(at: [0, -1, -0.5], from: [0, 1, 0.5], relativeTo: flowerEntity)
-
+        
         // 🌤️ 부드러운 전체 조명: 그림자 어두움을 줄이기 위해 Ambient 느낌 추가
         let ambientLight = PointLight()
         ambientLight.light.intensity = 3000
         ambientLight.light.color = UIColor(red: 1.0, green: 0.97, blue: 0.9, alpha: 1.0)
         ambientLight.light.attenuationRadius = 2.0
         ambientLight.position = [0, 0.5, 0]
-
+        
         // 조명들을 꽃에 추가
         flowerEntity.addChild(directionalLight)
         flowerEntity.addChild(ambientLight)
@@ -240,7 +240,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         // 🌤️ 하늘 산란광: 부드러운 전체 조명 (하늘에서 오는 간접광)
         let skyLight = createSkyAmbientLight(color: sunlightColor)
         
-    
+        
         
         // 📐 카메라 위치 기반 보조 조명 (너무 어두운 부분 방지)
         let fillLight = createCameraFillLight(cameraPosition: cameraPosition, flowerPosition: flowerEntity.position)
@@ -313,7 +313,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         return skyLight
     }
     
-   
+    
     
     // MARK: - 카메라 보조 조명 (자연스러운 fill light)
     private func createCameraFillLight(cameraPosition: SIMD3<Float>, flowerPosition: SIMD3<Float>) -> PointLight {
@@ -446,7 +446,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         removePlacementAnchor() // 앵커 제거
         onPlacementStateChanged?(placementState.status)
     }
-
+    
     // MARK: - 나침반 기준 꽃 방향 계산
     private func calculateFlowerRotationFromHeading() -> simd_quatf {
         guard let userHeading = currentUserHeading else {
@@ -479,24 +479,14 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         
         return rotation
     }
-
+    
     // MARK: - 꽃이 바라볼 목표 방향 결정
     private func getFlowerTargetHeading(userHeading: Double) -> Double {
-        // 옵션 1: 사용자와 같은 방향 (사용자가 보는 방향)
-        let sameDirection = userHeading
         
-        // 옵션 2: 사용자 반대 방향 (사용자를 바라보는 방향)
+        // 사용자 반대 방향 (사용자를 바라보는 방향)
         let oppositeDirection = userHeading >= 180 ? userHeading - 180 : userHeading + 180
         
-        // 옵션 3: 고정 방향 (예: 항상 북쪽)
-        let fixedDirection = 0.0  // 북쪽
-        
-        // 🌸 원하는 설정 선택 (현재는 사용자와 같은 방향)
-        return sameDirection
-        
-        // 다른 옵션을 사용하려면 위의 return을 주석처리하고 아래 중 하나 선택:
-         return oppositeDirection  // 사용자를 바라보게 하려면
-        // return fixedDirection     // 항상 북쪽을 바라보게 하려면
+        return oppositeDirection  // 사용자를 바라보게 하려면
     }
     
     /// 현재 배치된 위치의 GPS 좌표를 반환합니다.
@@ -655,7 +645,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
     {
         Entity.loadModelAsync(named: modelName, in: .module)
             .catch { error -> AnyPublisher<ModelEntity, Error> in
-
+                
                 print("Failed to load model '\(modelName)': \(error)")
                 return Entity.loadModelAsync(named: modelName)
                     .eraseToAnyPublisher()
@@ -901,7 +891,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             transform.columns.3.z
         )
     }
-
+    
     private func extractForwardFromTransform(_ transform: simd_float4x4) -> SIMD3<Float> {
         return -SIMD3<Float>(
             transform.columns.2.x,
@@ -909,7 +899,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             transform.columns.2.z
         )
     }
-
+    
     
     
     // MARK: - Placement Anchor Creation (수정된 버전)
@@ -954,18 +944,18 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         )
         
         let animationResource = try? AnimationResource.generate(with: scaleAnimation)
-       
+        
         
         // 그림자 효과
         let shadowMesh = MeshResource.generatePlane(width: 0.25, depth: 0.25,cornerRadius: 50)
-       
-  
-
+        
+        
+        
         var shadowMaterial = UnlitMaterial()
         shadowMaterial.baseColor = MaterialColorParameter.color(UIColor.red.withAlphaComponent(0.3))
         
-     
-   
+        
+        
         let shadow = ModelEntity(mesh: shadowMesh, materials: [shadowMaterial])
         shadow.position.y = -0.12
         
@@ -995,22 +985,22 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
     
     func makeDashedCircle(radius: Float, dotCount: Int, dotSize: Float, color: UIColor) -> Entity {
         let parent = Entity()
-
+        
         for i in 0..<dotCount {
             let angle = (Float(i) / Float(dotCount)) * 2 * Float.pi
             let x = cos(angle) * radius
             let z = sin(angle) * radius
-
+            
             let dotMesh = MeshResource.generateSphere(radius: dotSize)
             var dotMaterial = UnlitMaterial()
             dotMaterial.baseColor = .color(color)
-
+            
             let dotEntity = ModelEntity(mesh: dotMesh, materials: [dotMaterial])
             dotEntity.position = [x, 0, z]
-
+            
             parent.addChild(dotEntity)
         }
-
+        
         return parent
     }
     

--- a/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
+++ b/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
@@ -196,6 +196,28 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             .store(in: &cancellables)
     }
     
+    private func addLightingToFlower(_ flowerEntity: ModelEntity) {
+        // 🌞 방향성 조명: 햇빛 역할
+        let directionalLight = DirectionalLight()
+        directionalLight.light.intensity = 10000  // 더 강하게
+        directionalLight.light.color = UIColor(red: 1.0, green: 0.96, blue: 0.85, alpha: 1.0) // 햇빛 느낌의 따뜻한 색
+
+        // 햇빛이 약간 비스듬하게 비추는 느낌 (예: 남동쪽 방향에서)
+        directionalLight.look(at: [0, -1, -0.5], from: [0, 1, 0.5], relativeTo: flowerEntity)
+
+        // 🌤️ 부드러운 전체 조명: 그림자 어두움을 줄이기 위해 Ambient 느낌 추가
+        let ambientLight = PointLight()
+        ambientLight.light.intensity = 5000
+        ambientLight.light.color = UIColor(red: 1.0, green: 0.97, blue: 0.9, alpha: 1.0)
+        ambientLight.light.attenuationRadius = 2.0
+        ambientLight.position = [0, 0.5, 0]
+
+        // 조명들을 꽃에 추가
+        flowerEntity.addChild(directionalLight)
+        flowerEntity.addChild(ambientLight)
+    }
+
+    
     func confirmPlacement() {
         guard placementState.canConfirm,
               let arView = arView,
@@ -232,6 +254,7 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
             
             // 꽃 엔티티에 회전 적용
             flowerClone.transform.rotation = rotation
+            addLightingToFlower(flowerClone)
             
             flowerAnchor.addChild(flowerClone)
             arView.scene.addAnchor(flowerAnchor)

--- a/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
+++ b/Packages/Features/Sources/Features/ARCamera/placement/ARSceneManager.swift
@@ -112,6 +112,19 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
                 return .systemRed
             }
         }
+        
+        var success : Bool {
+            switch self {
+            case .idle:
+                return false
+            case .success:
+                return true
+            case .fallback:
+                return false
+            case .failed:
+                return false
+            }
+        }
     }
     
     
@@ -217,7 +230,6 @@ class ARSceneManager: NSObject, ARSessionDelegate, ObservableObject {
         flowerEntity.addChild(ambientLight)
     }
 
-    
     func confirmPlacement() {
         guard placementState.canConfirm,
               let arView = arView,

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -139,7 +139,7 @@ public struct RecordDetailBottomSheet: View {
         
         var body: some View {
             HStack(spacing: 8) {
-                DesignSystemAssets.image(named: "mainFlower")
+                DesignSystemAssets.image(named: "MainFlower")
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 17, height: 17)

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetView.swift
@@ -117,7 +117,7 @@ private struct SelectedFlowerCardView: View {
     var body: some View {
         VStack(spacing: 8) {
             HStack(spacing: 4) {
-                DesignSystemAssets.image(named: "flower_icon")
+                DesignSystemAssets.image(named: "MainFlower")
                     .resizable()
                     .frame(width: 16, height: 16)
                 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

### 📌 관련 이슈 (Related Issue)
- Closes #152 

---

### 🧶 주요 변경 내용 (Summary)

- ✅ **AR 배치 모드 개선**
  - 배치 확정 후 `ARFlowerButton` 숨김 처리 (뷰 정렬을 위해 빈 뷰로 대체)
  - `statusMessage` 문구 개선: 
    - 배치 확정 후 → `"다른 곳을 비쳐서 재배치 버튼을 탭하면\n다시 심을 수 있어요"`
    - 재배치 시 → `"🔴 여기에 \(flower.name)를 심을까요?"`

- 🪷 **AR UI 기능 개선**
  - 꽃이 항상 카메라 방향을 향하도록 변경
  - 배치 전 꽃의 위치 미리 보여주는 UI 개선

- 🧱 **디자인 시스템 및 리소스 관련 수정**
  - `RecordDetailBottomSheet`, `RecordSaveSheet`에서 잘못된 asset 이름 수정
  - 꽃 크기 조정

---

### 📸 스크린샷 (Optional)

<!-- 필요 시 여기에 UI 작업 결과 첨부 -->
<!-- <img width="300" alt="AR flower placement" src="https://..."> -->

---

### 🧪 테스트 / 검증 내역

- [x] AR 배치 및 재배치 흐름 테스트 완료
- [x] 꽃 방향이 항상 카메라를 향하는지 확인
- [x] iPhone 15 / iOS 17.4에서 UI 정상 작동 확인
- [ ] 다크모드 대응 (추후 대응 예정, #이슈번호)

---

### 💬 기타 공유 사항

- 꽃 크기는 디자인 시안 기준에 맞춰 1차 조정 → 추가 조율 필요 시 디자이너와 협의 예정

---

### 🙇🏻‍♀️ 리뷰 가이드
