### PR TITLE
♻️ Refactor: #156 CustomAlbumViewModel 이미지 로딩 성능 최적화 및 안정성 강화

### DIFF
--- a/Packages/Features/Sources/Features/CustomAlbum/AlbumGridItemView.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/AlbumGridItemView.swift
@@ -13,21 +13,12 @@ struct AlbumGridItemView: View {
     let asset: PHAsset
     let isSelected: Bool
     let selectedIndex: Int?
-    let viewModel: CustomAlbumViewModel
+    @ObservedObject var viewModel: CustomAlbumViewModel
     let cellSize: CGFloat
-
-    @State private var image: UIImage?
     
-    init(asset: PHAsset, isSelected: Bool, selectedIndex: Int?, viewModel: CustomAlbumViewModel, cellSize: CGFloat) {
-        self.asset = asset
-        self.isSelected = isSelected
-        self.selectedIndex = selectedIndex
-        self.viewModel = viewModel
-        self.cellSize = cellSize
-        // State 변수를 ViewModel의 캐시 값으로 초기화합니다.
-        _image = State(initialValue: viewModel.getCachedImage(for: asset))
-    }
-
+    @State private var image: UIImage?
+    @State private var isImageLoaded = false // 이미지 로딩 완료 여부 추적
+    
     var body: some View {
         ZStack {
             if let img = image {
@@ -42,23 +33,41 @@ struct AlbumGridItemView: View {
         .clipped()
         .contentShape(Rectangle())
         .overlay(selectionOverlay)
-        .onAppear {
-            if image == nil {
-                Task {
-                    let thumbnailSize = CGSize(width: cellSize * UIScreen.main.scale, height: cellSize * UIScreen.main.scale)
-                    self.image = await viewModel.fetchImage(for: asset, size: thumbnailSize)
-                }
+        .task(id: asset.localIdentifier) {
+            // 이미 로딩된 이미지가 있으면 다시 로딩하지 않음
+            guard !isImageLoaded else { return }
+            
+            let imageSize = CGSize(width: cellSize * UIScreen.main.scale, height: cellSize * UIScreen.main.scale)
+            
+            // 1단계: 캐시된 이미지 먼저 시도 (빠른 표시)
+            if let cachedImage = await viewModel.fetchImage(
+                for: asset,
+                targetSize: imageSize,
+                preferCached: true,
+                highQuality: false
+            ) {
+                self.image = cachedImage
+            }
+            
+            // 2단계: 고화질 이미지 로딩 (앨범에서도 고화질 사용)
+            if let highQualityImage = await viewModel.fetchImage(
+                for: asset,
+                targetSize: imageSize,
+                preferCached: false,
+                highQuality: true
+            ) {
+                self.image = highQualityImage
+                self.isImageLoaded = true // 고화질 로딩 완료 표시
             }
         }
-
     }
-
+    
     @ViewBuilder
     private var selectionOverlay: some View {
         if isSelected, let idx = selectedIndex {
             ZStack(alignment: .topTrailing) {
                 Color.black.opacity(0.4)
-
+                
                 Text("\(idx + 1)")
                     .font(.caption.bold())
                     .foregroundColor(.white)

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumView.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumView.swift
@@ -8,6 +8,8 @@ struct CustomAlbumView: View {
     
     @State private var showLimitAlert = false
     
+    @State private var visibleIndices: IndexSet = []
+    
     private let columns = 3
     private let spacing: CGFloat = 2
     private var gridItems: [GridItem] {
@@ -16,6 +18,11 @@ struct CustomAlbumView: View {
     private var cellSize: CGFloat {
         let totalSpacing = spacing * CGFloat(columns - 1)
         return (UIScreen.main.bounds.width - totalSpacing) / CGFloat(columns)
+    }
+    
+    private var targetThumbnailSize: CGSize {
+        let scale = UIScreen.main.scale
+        return CGSize(width: cellSize * scale, height: cellSize * scale)
     }
     
     var body: some View {
@@ -50,6 +57,12 @@ struct CustomAlbumView: View {
                                     viewModel.toggleAssetSelection(asset)
                                 }
                             }
+                            .onAppear {
+                                visibleIndices.insert(index)
+                            }
+                            .onDisappear {
+                                visibleIndices.remove(index)
+                            }
                         }
                     }
                 } else {
@@ -58,10 +71,15 @@ struct CustomAlbumView: View {
             }
         }
         .onAppear {
-            viewModel.prepareForAllPhotos()
+            // ◀️ View가 나타날 때, 계산된 셀 크기로 초기 캐싱을 요청합니다.
+            viewModel.startInitialCaching(targetSize: targetThumbnailSize)
         }
         .alert("최대 \(viewModel.maxImageCount)장까지 선택할 수 있어요", isPresented: $showLimitAlert) {
             Button("확인", role: .cancel) { }
+        }
+        .onChange(of: visibleIndices) { _, newIndices in
+            // ◀️ 스크롤 시 보이는 인덱스가 바뀔 때마다 셀 크기와 함께 캐싱 업데이트를 요청합니다.
+            viewModel.updateCachedAssets(visibleIndices: newIndices, targetSize: targetThumbnailSize)
         }
     }
     

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
@@ -6,68 +6,224 @@
 //
 
 import Combine
+import Foundation
 import Photos
 import SwiftUI
 
 @MainActor
 public final class CustomAlbumViewModel: ObservableObject {
     
+    // MARK: - Published Properties
+    
     @Published var recentPhotoAssets: [PHAsset] = []
-    @Published var allPhotoAssetsResult: PHFetchResult<PHAsset>?
+    @Published var allPhotoAssetsResult: PHFetchResult<PHAsset>? // 전체 앨범을 위한 데이터 소스
     
     @Published var selectedAssets: [PHAsset] = []
     
     @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
     @Published var isLoading = false
     
-    private let cachingImageManager = PHCachingImageManager()
-    private var imageCache: [String: UIImage] = [:]
+    // MARK: - Properties
     
     let maxImageCount = 4
-    
     let selectionDidFinishPublisher = PassthroughSubject<[PHAsset], Never>()
     
+    private let cachingImageManager = PHCachingImageManager()
+    private var previousCachedIndices: IndexSet = IndexSet()
+    
+    private let thumbnailOptions: PHImageRequestOptions = {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .fastFormat
+        options.isNetworkAccessAllowed = false // 썸네일은 로컬만
+        options.isSynchronous = false
+        return options
+    }()
+    
+    private let highQualityOptions: PHImageRequestOptions = {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .highQualityFormat
+        options.isNetworkAccessAllowed = true
+        options.isSynchronous = false
+        return options
+    }()
+    
+    // MARK: - Initialization
+    
     public init() {
-        fetchInitialRecentAssets()
+        fetchInitialData()
     }
     
-    public func getCachedImage(for asset: PHAsset) -> UIImage? {
-         return imageCache[asset.localIdentifier]
-     }
+    // MARK: - Caching Logic
     
-    func fetchInitialRecentAssets() {
+    /// View가 나타날 때 호출되어, 첫 화면에 보일 이미지들의 캐싱을 시작합니다.
+    /// - Parameter targetSize: 캐싱할 이미지의 크기 (View의 셀 크기와 일치해야 함)
+    public func startInitialCaching(targetSize: CGSize) {
+        guard let assets = allPhotoAssetsResult, assets.count > 0 else { return }
+        
+        // 이미 캐싱된 경우 중복 실행 방지
+        guard previousCachedIndices.isEmpty else { return }
+        
+        let initialCacheCount = min(assets.count, 50)
+        let initialIndices = IndexSet(0..<initialCacheCount)
+        let assetsToCache = assets.objects(at: initialIndices)
+        
+        cachingImageManager.startCachingImages(
+            for: assetsToCache,
+            targetSize: targetSize,
+            contentMode: .aspectFill,
+            options: thumbnailOptions // 썸네일 옵션 사용
+        )
+        
+        previousCachedIndices = initialIndices
+    }
+    
+    /// 스크롤 시 View에서 호출되어, 화면에 보이거나 보일 예정인 셀들의 캐싱을 관리합니다.
+    /// - Parameters:
+    ///   - visibleIndices: 현재 화면에 보이는 셀들의 인덱스
+    ///   - targetSize: 캐싱할 이미지의 크기 (View의 셀 크기와 일치해야 함)
+    public func updateCachedAssets(visibleIndices: IndexSet, targetSize: CGSize) {
+        guard let assets = allPhotoAssetsResult else { return }
+        
+        let buffer = 25
+        let minIndex = max(0, (visibleIndices.min() ?? 0) - buffer)
+        let maxIndex = min(assets.count - 1, (visibleIndices.max() ?? 0) + buffer)
+        
+        guard minIndex <= maxIndex else { return }
+        
+        let currentIndicesToCache = IndexSet(integersIn: minIndex...maxIndex)
+        guard currentIndicesToCache != previousCachedIndices else { return }
+        
+        let newAssetsToCacheIndices = currentIndicesToCache.subtracting(previousCachedIndices)
+        let oldAssetsToStopCachingIndices = previousCachedIndices.subtracting(currentIndicesToCache)
+        
+        if !newAssetsToCacheIndices.isEmpty {
+            let assetsToCache = assets.objects(at: newAssetsToCacheIndices)
+            cachingImageManager.startCachingImages(
+                for: assetsToCache,
+                targetSize: targetSize,
+                contentMode: .aspectFill,
+                options: thumbnailOptions // 썸네일 옵션 사용
+            )
+        }
+        
+        if !oldAssetsToStopCachingIndices.isEmpty {
+            let assetsToStop = assets.objects(at: oldAssetsToStopCachingIndices)
+            cachingImageManager.stopCachingImages(
+                for: assetsToStop,
+                targetSize: targetSize,
+                contentMode: .aspectFill,
+                options: thumbnailOptions
+            )
+        }
+        
+        previousCachedIndices = currentIndicesToCache
+    }
+    
+    
+    // MARK: - Data Fetching
+    
+    /// ViewModel 초기화 시 호출되어, 사진첩 데이터를 가져옵니다.
+    private func fetchInitialData() {
         isLoading = true
         checkPermission { [weak self] hasPermission in
-            guard let self = self, hasPermission else {
+            guard let self, hasPermission else {
                 DispatchQueue.main.async { self?.isLoading = false }
                 return
             }
-
+            
             DispatchQueue.global(qos: .userInitiated).async {
-                let fetchOptions = PHFetchOptions()
-                fetchOptions.sortDescriptors = [
-                    NSSortDescriptor(key: "creationDate", ascending: false)
-                ]
-                fetchOptions.fetchLimit = 20
-
-                let fetchResult = PHAsset.fetchAssets(
-                    with: .image,
-                    options: fetchOptions
-                )
-                var assets: [PHAsset] = []
-                fetchResult.enumerateObjects { asset, _, _ in
-                    assets.append(asset)
+                // --- 최근 사진 20개 가져오기 ---
+                let recentFetchOptions = PHFetchOptions()
+                recentFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+                recentFetchOptions.fetchLimit = 20
+                
+                let recentResult = PHAsset.fetchAssets(with: .image, options: recentFetchOptions)
+                var recentAssets: [PHAsset] = []
+                recentResult.enumerateObjects { asset, _, _ in
+                    recentAssets.append(asset)
                 }
-
+                
+                // --- 모든 사진에 대한 FetchResult 가져오기 ---
+                let allFetchOptions = PHFetchOptions()
+                allFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+                let allAssetsResult = PHAsset.fetchAssets(with: .image, options: allFetchOptions)
+                
+                // --- 메인 스레드에서 UI 업데이트 ---
                 DispatchQueue.main.async {
-                    self.recentPhotoAssets = assets
+                    self.recentPhotoAssets = recentAssets
+                    self.allPhotoAssetsResult = allAssetsResult
                     self.isLoading = false
                 }
             }
         }
     }
     
-    // 커스텀 앨범에서 사진 선택/해제
+    public func fetchImage(
+        for asset: PHAsset,
+        targetSize: CGSize,
+        preferCached: Bool = true,
+        highQuality: Bool = false
+    ) async -> UIImage? {
+        
+        if preferCached {
+            if let cachedImage = await requestCachedImageAsync(for: asset, targetSize: targetSize) {
+                // 고화질이 필요하지 않으면 캐시된 이미지 반환
+                if !highQuality {
+                    return cachedImage
+                }
+                // 고화질이 필요한 경우에도 일단 캐시된 이미지를 먼저 반환할 수 있도록
+            }
+        }
+        
+        // 새로운 이미지 요청
+        let options = highQuality ? highQualityOptions : thumbnailOptions
+        
+        return await withCheckedContinuation { continuation in
+            var isResumed = false
+            cachingImageManager.requestImage(
+                for: asset,
+                targetSize: targetSize,
+                contentMode: .aspectFill,
+                options: options
+            ) { image, info in
+                guard !isResumed else { return }
+                
+                let isError = info?[PHImageErrorKey] != nil
+                let isCancelled = (info?[PHImageCancelledKey] as? Bool) ?? false
+                
+                if let image {
+                    continuation.resume(returning: image)
+                    isResumed = true
+                } else if isError || isCancelled {
+                    continuation.resume(returning: nil)
+                    isResumed = true
+                }
+            }
+        }
+    }
+    
+    /// 캐시에서 이미지를 비동기적으로 가져옴
+    private func requestCachedImageAsync(for asset: PHAsset, targetSize: CGSize) async -> UIImage? {
+        return await withCheckedContinuation { continuation in
+            let options = PHImageRequestOptions()
+            options.isSynchronous = false // 비동기로 변경
+            options.deliveryMode = .fastFormat
+            options.isNetworkAccessAllowed = false // 캐시된 이미지만
+            
+            cachingImageManager.requestImage(
+                for: asset,
+                targetSize: targetSize,
+                contentMode: .aspectFill,
+                options: options
+            ) { image, info in
+                // 캐시에서만 가져오므로 즉시 완료
+                continuation.resume(returning: image)
+            }
+        }
+    }
+    
+    // MARK: - Asset Selection
+    
     func toggleAssetSelection(_ asset: PHAsset) {
         if let index = selectedAssets.firstIndex(of: asset) {
             selectedAssets.remove(at: index)
@@ -77,64 +233,19 @@ public final class CustomAlbumViewModel: ObservableObject {
     }
     
     func finalizeSelection() {
-         selectionDidFinishPublisher.send(selectedAssets)
-     }
+        selectionDidFinishPublisher.send(selectedAssets)
+    }
     
     func clearSelectedAssets() {
         selectedAssets.removeAll()
     }
     
-    func prepareForAllPhotos() {
-        guard allPhotoAssetsResult == nil else { return }
-
-        checkPermission { [weak self] hasPermission in
-            guard let self = self, hasPermission else { return }
-
-            let opts = PHFetchOptions()
-            opts.sortDescriptors = [
-                NSSortDescriptor(key: "creationDate", ascending: false)
-            ]
-            self.allPhotoAssetsResult = PHAsset.fetchAssets(
-                with: .image,
-                options: opts
-            )
-        }
-    }
-    
-    public func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
-            // 캐시에 이미지가 있으면 즉시 반환합니다.
-            if let cachedImage = imageCache[asset.localIdentifier] {
-                return cachedImage
-            }
-            
-            // 캐시에 없으면 PHCachingImageManager를 통해 이미지를 요청합니다.
-            let options = PHImageRequestOptions()
-            options.deliveryMode = .highQualityFormat
-            options.isNetworkAccessAllowed = true
-
-            let image = await withCheckedContinuation { continuation in
-                cachingImageManager.requestImage(
-                    for: asset,
-                    targetSize: size,
-                    contentMode: .aspectFill,
-                    options: options
-                ) { image, _ in
-                    continuation.resume(returning: image)
-                }
-            }
-            
-            // 로드된 이미지를 캐시에 저장합니다.
-            if let loadedImage = image {
-                imageCache[asset.localIdentifier] = loadedImage
-            }
-            
-            return image
-        }
+    // MARK: - Permissions
     
     private func checkPermission(completion: @escaping (Bool) -> Void) {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
         self.authorizationStatus = status
-
+        
         switch status {
         case .authorized, .limited:
             completion(true)
@@ -142,18 +253,11 @@ public final class CustomAlbumViewModel: ObservableObject {
             PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
                 DispatchQueue.main.async {
                     self.authorizationStatus = newStatus
-                    completion(
-                        newStatus == .authorized || newStatus == .limited
-                    )
+                    completion(newStatus == .authorized || newStatus == .limited)
                 }
             }
-        default:  // .denied, .restricted
+        default: // .denied, .restricted
             completion(false)
         }
     }
-    
-    
 }
-
-
-

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
@@ -34,7 +34,7 @@ public final class CustomAlbumViewModel: ObservableObject {
     private let thumbnailOptions: PHImageRequestOptions = {
         let options = PHImageRequestOptions()
         options.deliveryMode = .fastFormat
-        options.isNetworkAccessAllowed = false // 썸네일은 로컬만
+        options.isNetworkAccessAllowed = false
         options.isSynchronous = false
         return options
     }()
@@ -165,50 +165,45 @@ public final class CustomAlbumViewModel: ObservableObject {
         highQuality: Bool = false
     ) async -> UIImage? {
         
-        if preferCached {
+        // 캐시 확인 (저화질 요청이고 캐시 우선인 경우)
+        if preferCached && !highQuality {
             if let cachedImage = await requestCachedImageAsync(for: asset, targetSize: targetSize) {
-                // 고화질이 필요하지 않으면 캐시된 이미지 반환
-                if !highQuality {
-                    return cachedImage
-                }
-                // 고화질이 필요한 경우에도 일단 캐시된 이미지를 먼저 반환할 수 있도록
+                return cachedImage
             }
         }
         
-        // 새로운 이미지 요청
+        // 새로운 이미지 요청 (캐시에 없거나 고화질 필요한 경우)
         let options = highQuality ? highQualityOptions : thumbnailOptions
         
         return await withCheckedContinuation { continuation in
-            var isResumed = false
             cachingImageManager.requestImage(
                 for: asset,
                 targetSize: targetSize,
                 contentMode: .aspectFill,
                 options: options
             ) { image, info in
-                guard !isResumed else { return }
-                
                 let isError = info?[PHImageErrorKey] != nil
                 let isCancelled = (info?[PHImageCancelledKey] as? Bool) ?? false
                 
                 if let image {
                     continuation.resume(returning: image)
-                    isResumed = true
                 } else if isError || isCancelled {
                     continuation.resume(returning: nil)
-                    isResumed = true
+                } else {
+                    continuation.resume(returning: nil)
                 }
             }
         }
     }
     
-    /// 캐시에서 이미지를 비동기적으로 가져옴
+    /// 캐시에서 이미지를 비동기적으로 페칭 (실제 캐시된 이미지만 반환)
     private func requestCachedImageAsync(for asset: PHAsset, targetSize: CGSize) async -> UIImage? {
         return await withCheckedContinuation { continuation in
             let options = PHImageRequestOptions()
-            options.isSynchronous = false // 비동기로 변경
+            options.isSynchronous = false
             options.deliveryMode = .fastFormat
-            options.isNetworkAccessAllowed = false // 캐시된 이미지만
+            options.isNetworkAccessAllowed = false
+            options.resizeMode = .fast
             
             cachingImageManager.requestImage(
                 for: asset,
@@ -216,8 +211,17 @@ public final class CustomAlbumViewModel: ObservableObject {
                 contentMode: .aspectFill,
                 options: options
             ) { image, info in
-                // 캐시에서만 가져오므로 즉시 완료
-                continuation.resume(returning: image)
+                // info 딕셔너리를 확인하여 실제 캐시된 이미지인지 검증
+                let isFromCloud = (info?[PHImageResultIsInCloudKey] as? Bool) ?? false
+                let isError = info?[PHImageErrorKey] != nil
+                
+                // 캐시된 이미지만 반환 (클라우드에서 가져오거나 에러가 있으면 nil)
+                if let image = image, !isFromCloud, !isError {
+                    continuation.resume(returning: image)
+                } else {
+                    // 캐시에 없거나 클라우드에서 가져와야 하는 경우 nil 반환
+                    continuation.resume(returning: nil)
+                }
             }
         }
     }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
@@ -101,7 +101,7 @@ struct ImageCarouselView: View {
         }
         .scrollTargetBehavior(.viewAligned)
         .frame(height: fullSize)
-        .sheet(isPresented: $isCustomAlbumPresented) {
+        .fullScreenCover(isPresented: $isCustomAlbumPresented) {
             CustomAlbumView(viewModel: albumViewModel)
         }
         .onAppear {

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -173,14 +173,21 @@ public final class RecordDetailViewModel: ObservableObject {
 
     // MARK: - Image Handling
 
-   func addImages(from assets: [PHAsset], using albumViewModel: CustomAlbumViewModel) {
+    func addImages(from assets: [PHAsset], using albumViewModel: CustomAlbumViewModel) {
         guard detail != nil else { return }
         
         isLoading = true
         Task {
             var newImages: [UIImage] = []
+            
             for asset in assets {
-                if let image = await albumViewModel.fetchImage(for: asset, size: PHImageManagerMaximumSize) {
+                // 레코드 상세에 추가하는 이미지이므로 최고 품질로 요청
+                if let image = await albumViewModel.fetchImage(
+                    for: asset,
+                    targetSize: PHImageManagerMaximumSize, // 원본에 가까운 최고 해상도 요청
+                    preferCached: false, // 최고 품질이므로 캐시 무시하고 새로 요청
+                    highQuality: true    // 최고 품질로 요청
+                ) {
                     newImages.append(image)
                 }
             }

--- a/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/PhotoSelectionView.swift
@@ -56,7 +56,6 @@ public struct PhotoSelectionView: View {
     @ViewBuilder
     private var photoLibraryButton: some View {
         Button(action: {
-            viewModel.prepareForAllPhotos()
             showCustomAlbum = true
         }) {
             HStack {

--- a/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecentPhotosView.swift
@@ -93,7 +93,8 @@ private struct PhotoItemView: View {
     let action: () -> Void
     
     @State private var image: UIImage?
-
+    @State private var isImageLoaded = false // 이미지 로딩 완료 여부 추적
+    
     var body: some View {
         Button(action: action) {
             ZStack {
@@ -115,9 +116,31 @@ private struct PhotoItemView: View {
             }
         }
         .buttonStyle(.plain)
-        .onAppear {
-            Task {
-                self.image = await viewModel.fetchImage(for: asset, size: CGSize(width: 250, height: 250))
+        .task(id: asset.localIdentifier) {
+            // 이미 로딩된 이미지가 있으면 다시 로딩하지 않음
+            guard !isImageLoaded else { return }
+            
+            let imageSize = CGSize(width: 250, height: 250) // RecentPhotosView 아이템 크기에 맞는 사이즈
+            
+            // 1단계: 캐시된 이미지 먼저 시도 (빠른 표시)
+            if let cachedImage = await viewModel.fetchImage(
+                for: asset,
+                targetSize: imageSize,
+                preferCached: true,
+                highQuality: false
+            ) {
+                self.image = cachedImage
+            }
+            
+            // 2단계: 고화질 이미지 로딩 (최근 사진도 고화질로 표시)
+            if let highQualityImage = await viewModel.fetchImage(
+                for: asset,
+                targetSize: imageSize,
+                preferCached: false,
+                highQuality: true
+            ) {
+                self.image = highQualityImage
+                self.isImageLoaded = true // 고화질 로딩 완료 표시
             }
         }
     }

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -103,10 +103,14 @@ public final class RecordSaveSheetViewModel: ObservableObject {
         Task {
             self.isLoading = true
             var images: [UIImage] = []
+            
             for asset in assets {
+                // 새로 통합된 fetchImage 메서드 사용 - 최종 선택이므로 고화질로 요청
                 if let image = await albumViewModel.fetchImage(
                     for: asset,
-                    size: CGSize(width: 400, height: 400)
+                    targetSize: CGSize(width: 400, height: 400),
+                    preferCached: false, // 최종 저장용이므로 캐시 무시하고 새로 요청
+                    highQuality: true    // 고화질로 요청
                 ) {
                     images.append(image)
                 }
@@ -133,14 +137,7 @@ public final class RecordSaveSheetViewModel: ObservableObject {
     
     // MARK: - Pass-through Methods to AlbumViewModel
     
-    /// View의 요청을 AlbumViewModel에 전달하는 역할
-    public func prepareForAllPhotos() {
-        albumViewModel.prepareForAllPhotos()
-    }
     
-    public func fetchImage(for asset: PHAsset, size: CGSize) async -> UIImage? {
-        return await albumViewModel.fetchImage(for: asset, size: size)
-    }
 }
 
 public struct SelectedFlowerModel {
@@ -148,7 +145,7 @@ public struct SelectedFlowerModel {
     public let name: String
     public let meaning: String
     public let imageName: String
-
+    
     public init(
         id: UUID = UUID(),
         name: String,
@@ -166,7 +163,7 @@ public struct Record {
     public let id: UUID
     public let flower: SelectedFlowerModel
     public let imageFileNames: [String]
-
+    
     public init(
         id: UUID = UUID(),
         flower: SelectedFlowerModel,


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #156 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. 사전 캐싱 전략 도입
  - PHCachingImageManager.startCachingImages/stopCachingImages 활용
  - 스크롤 위치 기반으로 향후 표시될 이미지 미리 로드
  - 저화질 썸네일 우선 캐싱으로 백그라운드 부하 최소화
2. 2단계 이미지 로딩
  - 저화질 이미지 즉시 표시 → 이후 고화질 이미지로 교체하는 순차 로딩 구현
3. 비동기 안정성 강화
  - withCheckedContinuation 중복 호출 방지 플래그 적용
  - 이전 캐싱 인덱스와 비교해 불필요한 캐싱 명령 제거
4. 중복 로딩 방지
  - isImageLoaded 플래그 추가해 .task 반복 실행 시 불필요한 로딩 차단

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 스크롤 시 빈 화면이나 깜빡임 현상이 개선되었는지 확인
- [x] 연속 스크롤 시 중복 로딩 없이 원활한 이미지 표시 여부 검증

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

fetchInitialData, updateCachedAssets, requestCachedImageAsync 메서드와
사전 캐싱 로직 변경 부분을 중점적으로 확인해주시면 좋습니다.