### PR TITLE
🛠 Fix: #163 초기 갤러리 접근 크래시 및 ARCameraView 위치 권한 오류 해결

### DIFF
--- a/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
@@ -141,23 +141,56 @@ public class ARCameraViewModel: NSObject, ObservableObject {
     func setupARView(_ arView: ARView) {
         arSceneManager.setup(arView: arView)
         locationManager.delegate = self
-        locationManager.requestWhenInUseAuthorization()
-        locationManager.startUpdatingHeading()
     }
 
     func startARSession() {
         print("🚀 AR 세션 시작")
 
-        // 위치 서비스 시작
-        locationManager.delegate = self
-        locationManager.requestWhenInUseAuthorization()
-        locationManager.startUpdatingHeading()
-        locationManager.startUpdatingLocation()
+        // ✅ 권한 상태 확인 후 위치 서비스 시작 (한 번만)
+        checkLocationPermissionAndStart()
 
         // 데이터 로드 및 배치
         Task {
             await fetchAndPlaceRecords()
         }
+    }
+
+    // MARK: - Location Permission Management
+    
+    /// 위치 권한을 확인하고 안전하게 위치 서비스를 시작합니다.
+    private func checkLocationPermissionAndStart() {
+        let authStatus = locationManager.authorizationStatus
+        
+        switch authStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            // ✅ 권한이 있으면 위치 서비스 시작
+            startLocationServices()
+            
+        case .notDetermined:
+            // ✅ 권한이 결정되지 않았으면 요청
+            locationManager.requestWhenInUseAuthorization()
+            
+        case .denied, .restricted:
+            // ❌ 권한이 거부되었으면 에러 메시지 표시
+            statusMessage = "위치 권한이 필요합니다. 설정에서 위치 접근을 허용해주세요."
+            
+        @unknown default:
+            // ❓ 알 수 없는 상태면 권한 요청
+            locationManager.requestWhenInUseAuthorization()
+        }
+    }
+    
+    /// 실제로 위치 서비스를 시작합니다.
+    private func startLocationServices() {
+        guard locationManager.authorizationStatus == .authorizedWhenInUse || 
+              locationManager.authorizationStatus == .authorizedAlways else {
+            print("❌ 위치 권한이 없어서 위치 서비스를 시작할 수 없습니다.")
+            return
+        }
+        
+        print("✅ 위치 서비스 시작")
+        locationManager.startUpdatingHeading()
+        locationManager.startUpdatingLocation()
     }
 
     // MARK: - AR Actions
@@ -410,71 +443,6 @@ public class ARCameraViewModel: NSObject, ObservableObject {
         )
     }
 
-    // MARK: - Mock Data Generation
-    private func makeMockDomainRecords() -> [Domain.Record] {
-        print("📊 Mock 데이터 생성 시작")
-
-        let titles = ["행복했던 강아지와의 산책", "맛있는 점심", "개발 공부"]
-        let distances: [Double] = [1.0, 3.0, 5.0]  // 1m, 3m, 5m
-        let bearings: [Double] = [0.0, 120.0, 240.0]  // 북쪽, 남동쪽, 남서쪽
-
-        var records: [Domain.Record] = []
-
-        for i in 0..<titles.count {
-            let title = titles[i]
-            let distance = distances[i]
-            let bearing = bearings[i]
-
-            // TransformUseCase를 사용하여 유효한 좌표 생성
-            let targetCoordinate = transformUseCase.generateValidTestCoordinate(
-                from: self.location.coordinate,
-                distance: distance,
-                bearing: bearing
-            )
-
-            let record = Domain.Record(
-                id: UUID(),
-                authorID: UUID(),
-                markerTypeID: UUID(),
-                title: title,
-                coordinate: Domain.Coordinate(
-                    latitude: targetCoordinate.latitude,
-                    longitude: targetCoordinate.longitude
-                ),
-                address: Domain.Address(fullAddress: "포항공과대학교"),
-                date: Date().addingTimeInterval(
-                    -Double.random(in: 0...3 * 24 * 3600)
-                ),  // 최근 3일 내
-                photos: [],
-                isPublic: true
-            )
-
-            print("📍 Mock 레코드 생성: \(title) at \(targetCoordinate)")
-            records.append(record)
-        }
-
-        return records
-    }
-
-    private func generateRandomCoordinate(
-        center: CLLocationCoordinate2D,
-        radiusInMeters: Double
-    ) -> CLLocationCoordinate2D {
-        let radiusInDegrees = radiusInMeters / 111_111.0
-
-        let angle = Double.random(in: 0..<(2 * .pi))
-        let radius = sqrt(Double.random(in: 0..<1)) * radiusInDegrees
-
-        let newLatitude = center.latitude + radius * cos(angle)
-        let newLongitude =
-            center.longitude + radius * sin(angle)
-            / cos(center.latitude * .pi / 180.0)
-
-        return CLLocationCoordinate2D(
-            latitude: newLatitude,
-            longitude: newLongitude
-        )
-    }
 }
 
 // MARK: - BottomSheetCoordinatorDelegate
@@ -516,7 +484,40 @@ extension ARCameraViewModel: CLLocationManagerDelegate {
         didFailWithError error: Error
     ) {
         Task { @MainActor in
+            print("❌ 위치 정보 오류: \(error.localizedDescription)")
             statusMessage = "위치 정보 오류: \(error.localizedDescription)"
+            
+            // GPS 신호 문제인 경우 재시도 유도
+            if let clError = error as? CLError, clError.code == .locationUnknown {
+                statusMessage = "GPS 신호를 찾고 있습니다. 잠시 후 다시 시도해주세요."
+            }
+        }
+    }
+    
+    /// 권한 상태가 변경되었을 때 호출됩니다.
+    public nonisolated func locationManager(
+        _ manager: CLLocationManager,
+        didChangeAuthorization status: CLAuthorizationStatus
+    ) {
+        Task { @MainActor in
+            print("📍 위치 권한 상태 변경: \(status.rawValue)")
+            
+            switch status {
+            case .authorizedWhenInUse, .authorizedAlways:
+                print("✅ 위치 권한 승인됨")
+                startLocationServices()
+                
+            case .denied, .restricted:
+                print("❌ 위치 권한 거부됨")
+                statusMessage = "위치 권한이 필요합니다. 설정에서 위치 접근을 허용해주세요."
+                
+            case .notDetermined:
+                print("❓ 위치 권한 미결정")
+                statusMessage = "위치 권한을 확인하고 있습니다..."
+                
+            @unknown default:
+                print("❓ 알 수 없는 위치 권한 상태")
+            }
         }
     }
 }

--- a/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
+++ b/Packages/Features/Sources/Features/CustomAlbum/CustomAlbumViewModel.swift
@@ -50,7 +50,10 @@ public final class CustomAlbumViewModel: ObservableObject {
     // MARK: - Initialization
     
     public init() {
-        fetchInitialData()
+        // ✅ 초기화 완료 후 비동기 데이터 로딩 시작
+        Task { @MainActor in
+            await fetchInitialData()
+        }
     }
     
     // MARK: - Caching Logic
@@ -123,39 +126,49 @@ public final class CustomAlbumViewModel: ObservableObject {
     // MARK: - Data Fetching
     
     /// ViewModel 초기화 시 호출되어, 사진첩 데이터를 가져옵니다.
-    private func fetchInitialData() {
+    @MainActor
+    private func fetchInitialData() async {
         isLoading = true
-        checkPermission { [weak self] hasPermission in
-            guard let self, hasPermission else {
-                DispatchQueue.main.async { self?.isLoading = false }
+        
+        do {
+            let hasPermission = await checkPermissionAsync()
+            guard hasPermission else {
+                isLoading = false
                 return
             }
             
-            DispatchQueue.global(qos: .userInitiated).async {
-                // --- 최근 사진 20개 가져오기 ---
-                let recentFetchOptions = PHFetchOptions()
-                recentFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-                recentFetchOptions.fetchLimit = 20
-                
-                let recentResult = PHAsset.fetchAssets(with: .image, options: recentFetchOptions)
-                var recentAssets: [PHAsset] = []
-                recentResult.enumerateObjects { asset, _, _ in
-                    recentAssets.append(asset)
-                }
-                
-                // --- 모든 사진에 대한 FetchResult 가져오기 ---
-                let allFetchOptions = PHFetchOptions()
-                allFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-                let allAssetsResult = PHAsset.fetchAssets(with: .image, options: allFetchOptions)
-                
-                // --- 메인 스레드에서 UI 업데이트 ---
-                DispatchQueue.main.async {
-                    self.recentPhotoAssets = recentAssets
-                    self.allPhotoAssetsResult = allAssetsResult
-                    self.isLoading = false
-                }
-            }
+            // PhotoKit API는 메인 스레드에서 호출 보장됨 (@MainActor)
+            await loadPhotoAssets()
+            
+        } catch {
+            print("Photo permission error: \(error)")
+            isLoading = false
         }
+    }
+    
+    /// 사진 에셋들을 로딩합니다.
+    @MainActor
+    private func loadPhotoAssets() async {
+        // --- 최근 사진 20개 가져오기 ---
+        let recentFetchOptions = PHFetchOptions()
+        recentFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        recentFetchOptions.fetchLimit = 20
+        
+        let recentResult = PHAsset.fetchAssets(with: .image, options: recentFetchOptions)
+        var recentAssets: [PHAsset] = []
+        recentResult.enumerateObjects { asset, _, _ in
+            recentAssets.append(asset)
+        }
+        
+        // --- 모든 사진에 대한 FetchResult 가져오기 ---
+        let allFetchOptions = PHFetchOptions()
+        allFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        let allAssetsResult = PHAsset.fetchAssets(with: .image, options: allFetchOptions)
+        
+        // --- UI 업데이트 (메인 액터에서 자동 보장) ---
+        self.recentPhotoAssets = recentAssets
+        self.allPhotoAssetsResult = allAssetsResult
+        self.isLoading = false
     }
     
     public func fetchImage(
@@ -246,22 +259,25 @@ public final class CustomAlbumViewModel: ObservableObject {
     
     // MARK: - Permissions
     
-    private func checkPermission(completion: @escaping (Bool) -> Void) {
+    /// 사진 권한을 비동기적으로 확인하고 요청합니다.
+    @MainActor
+    private func checkPermissionAsync() async -> Bool {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
         self.authorizationStatus = status
         
         switch status {
         case .authorized, .limited:
-            completion(true)
+            return true
+            
         case .notDetermined:
-            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
-                DispatchQueue.main.async {
-                    self.authorizationStatus = newStatus
-                    completion(newStatus == .authorized || newStatus == .limited)
-                }
-            }
+            // async/await로 권한 요청
+            let newStatus = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
+            self.authorizationStatus = newStatus
+            return newStatus == .authorized || newStatus == .limited
+            
         default: // .denied, .restricted
-            completion(false)
+            return false
         }
     }
+
 }


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #163 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. PhotoKit 메인 스레드 호출 보장
 - PHAsset.fetchAssets 호출을 메인 스레드에서만 실행되도록 수정
 - ViewModel init()에서 즉시 비동기 호출하지 않고, 권한 확인 이후 안전하게 fetch 수행
2. ARCameraView 위치 권한 로직 개선
 - CLLocationManager 권한 승인 완료 후에만 startLocationServices 호출
 - 권한 미승인 상태에서의 잘못된 위치 요청 방지
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 첫 실행 시 갤러리 접근 시 _dispatch_assert_queue_fail 크래시 재현되지 않음
- [x] 위치 권한 미승인 상태에서 오류 발생 없이 정상적으로 대기 후 재요청 가능
- [x] 권한 승인 후 위치 업데이트 정상 작동 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
