### PR TITLE
✨ Feat: #164 기록 저장 데이터 확장 및 MapView 연동 기능 추가

### DIFF
--- a/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraView.swift
@@ -21,10 +21,12 @@ public struct ARCameraView: View {
         @Dependency(\.saveRecordUseCase) var saveRecordUseCase
         @Dependency(\.initializeAppDataUseCase) var initializeAppDataUseCase
         @Dependency(\.fetchAllMarkersUseCase) var fetchAllMarkersUseCase
+        @Dependency(\.fetchRecordDetailUseCase) var fetchRecordDetailUseCase
 
         // 1. BottomSheetCoordinator를 먼저 생성합니다.
         let coordinator = BottomSheetCoordinator(
-            fetchAllMarkersUseCase: fetchAllMarkersUseCase
+            fetchAllMarkersUseCase: fetchAllMarkersUseCase,
+            fetchRecordDetailUseCase: fetchRecordDetailUseCase
         )
         
         // 2. ARCameraViewModel을 생성하면서 필요한 모든 의존성을 주입합니다.

--- a/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
+++ b/Packages/Features/Sources/Features/ARCamera/ARCameraViewModel.swift
@@ -323,7 +323,9 @@ public class ARCameraViewModel: NSObject, ObservableObject {
         }
     }
     private func handleRecordTapped(_ record: ARRecordModel) {
-        bottomSheetCoordinator.showRecordDetail(record: record)
+        Task {
+            await bottomSheetCoordinator.showRecordDetail(recordId: record.id)
+        }
     }
 
     private func handlePlacementStateChanged(_ status: ARPlacementState.Status)

--- a/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
+++ b/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
@@ -64,38 +64,23 @@ public class BottomSheetCoordinator: ObservableObject {
         print("📱 activeSheet = .flowerSelection 설정됨")
     }
 
-    // TODO record Id로 받아오기 -> usecase로 조회해오기
-    func showRecordDetail(record: ARRecordModel) {
-        print("📱 showRecordDetail 호출됨: \(record.title)")
-        selectedRecord = record
+    func showRecordDetail(recordId: UUID) async {
+        do {
+            // UseCase로 데이터 가져오기
+            let domainDetail = try await fetchRecordDetailUseCase(id: recordId)
+            
+            let viewModel = RecordDetailViewModel(
+                id: domainDetail.record.id, // domainDetail 안의 record를 전달
+                fetchRecordDetailUseCase: self.fetchRecordDetailUseCase
+            )
 
-        // 기본 RecordDetailViewModel 생성 후 데이터 설정
-        let viewModel = RecordDetailViewModel(
-            id: record.id,
-            fetchRecordDetailUseCase: fetchRecordDetailUseCase
-        )
-
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy년 M월 d일"
-
-        // 기존 방식과 동일하게 Mock 이미지 생성
-        let dummyPhotos = ["photo.artframe", "camera.fill", "tree.fill"]
-        let images = dummyPhotos.compactMap { UIImage(systemName: $0) }
-
-        // ARRecordModel의 데이터를 RecordDetailUIModel로 변환
-        let mockDetail = RecordDetailUIModel(
-            title: record.title.isEmpty ? "제목 없음" : record.title,
-            flowerName: "프리지아",
-            flowerMeaning: "영원한 사랑",
-            location: "포항공과대학교",
-            date: dateFormatter.string(from: record.createdDate),
-            images: images
-        )
-
-        viewModel.setDetail(mockDetail)
-        recordDetailViewModel = viewModel
-        activeSheet = .recordDetail
-        print("📱 RecordDetail 시트 설정 완료")
+            self.recordDetailViewModel = viewModel
+            self.activeSheet = .recordDetail
+            
+        } catch {
+            print("❌ 상세 기록을 불러오는 데 실패했습니다: \(error.localizedDescription)")
+            dismissSheet()
+        }
     }
 
     func showSaveSheet(

--- a/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
+++ b/Packages/Features/Sources/Features/ARCamera/BottomSheet/BottomSheetCoordinator.swift
@@ -24,13 +24,19 @@ public class BottomSheetCoordinator: ObservableObject {
     @Published var flowerSelectionViewModel: FlowerSelectionViewModel
     @Published var recordDetailViewModel: RecordDetailViewModel?
     @Published var saveSheetViewModel: RecordSaveSheetViewModel?
+    
+    private let fetchRecordDetailUseCase: FetchRecordDetailUseCase
 
     // MARK: - Delegate
     weak var delegate: BottomSheetCoordinatorDelegate?
 
     var onCancelPlacement: () -> Void = {}
 
-    init(fetchAllMarkersUseCase: FetchAllMarkersUseCase) {
+    init(
+        fetchAllMarkersUseCase: FetchAllMarkersUseCase,
+        fetchRecordDetailUseCase: FetchRecordDetailUseCase
+    ) {
+        self.fetchRecordDetailUseCase = fetchRecordDetailUseCase
         self.flowerSelectionViewModel = FlowerSelectionViewModel(
             fetchAllMarkersUseCase: fetchAllMarkersUseCase
         )
@@ -58,12 +64,16 @@ public class BottomSheetCoordinator: ObservableObject {
         print("📱 activeSheet = .flowerSelection 설정됨")
     }
 
+    // TODO record Id로 받아오기 -> usecase로 조회해오기
     func showRecordDetail(record: ARRecordModel) {
         print("📱 showRecordDetail 호출됨: \(record.title)")
         selectedRecord = record
 
         // 기본 RecordDetailViewModel 생성 후 데이터 설정
-        let viewModel = RecordDetailViewModel()
+        let viewModel = RecordDetailViewModel(
+            id: record.id,
+            fetchRecordDetailUseCase: fetchRecordDetailUseCase
+        )
 
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월 d일"

--- a/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
@@ -52,8 +52,8 @@ enum RecordMapper {
             authorID: UUID(),  // TODO: 실제 사용자 ID로 교체
             markerTypeID: placementData.flower.id,
             coordinate: Domain.Coordinate(
-                latitude: placementData.position.latitude,
-                longitude: placementData.position.longitude
+                latitude: finalLatitude,
+                longitude: finalLongitude
             ),
             // Address 모델의 실제 프로퍼티에 맞게 수정
             address: Domain.Address(fullAddress: payload.address),

--- a/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
@@ -56,7 +56,7 @@ enum RecordMapper {
                 longitude: placementData.position.longitude
             ),
             // Address 모델의 실제 프로퍼티에 맞게 수정
-            address: Domain.Address(fullAddress: )
+            address: Domain.Address(fullAddress: payload.address),
             date: placementData.placedAt,
             photos: photos, // ✅ 변환된 photos 배열 전달
             isPublic: true

--- a/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
+++ b/Packages/Features/Sources/Features/ARCamera/Mapper/RecordMapper.swift
@@ -30,8 +30,8 @@ enum RecordMapper {
         payload: FinalRecordPayload
     ) -> Domain.Record {
         // TODO: 이미지 저장 및 URL 변환 로직 필요
-        let photoURLs = payload.imageFileNames.compactMap { image in
-            URL(string: image)
+        let photos = payload.imageURLs.map { url in
+            Domain.Photo(url: url)
         }
 
         // ✅ 최종 저장되는 위치 정보 로그
@@ -49,16 +49,17 @@ enum RecordMapper {
 
         return Domain.Record(
             id: UUID(),
-            authorID: UUID(),  // TODO: Replace with actual author ID
+            authorID: UUID(),  // TODO: 실제 사용자 ID로 교체
             markerTypeID: placementData.flower.id,
             coordinate: Domain.Coordinate(
-                latitude: finalLatitude,
-                longitude: finalLongitude
+                latitude: placementData.position.latitude,
+                longitude: placementData.position.longitude
             ),
-            address: Domain.Address(fullAddress: payload.description),
+            // Address 모델의 실제 프로퍼티에 맞게 수정
+            address: Domain.Address(fullAddress: )
             date: placementData.placedAt,
-            photos: photoURLs.map { Domain.Photo(url: $0) },
-            isPublic: true  // TODO: Replace with actual visibility if needed
+            photos: photos, // ✅ 변환된 photos 배열 전달
+            isPublic: true
         )
     }
 

--- a/Packages/Features/Sources/Features/Map/MapView.swift
+++ b/Packages/Features/Sources/Features/Map/MapView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import MapKit
+import Dependencies
 import DesignSystem
 
 public struct MapView: View {
@@ -30,7 +31,14 @@ public struct MapView: View {
             viewModel.fetchMapObjects()
         }
         .sheet(item: $viewModel.selectObjectDetail) { summary in
-            RecordDetailBottomSheet(viewModel: RecordDetailViewModel(id: summary.id))
+            @Dependency(\.fetchRecordDetailUseCase) var fetchRecordDetailUseCase
+            
+            RecordDetailBottomSheet(
+                viewModel: RecordDetailViewModel(
+                    id: summary.id,
+                    fetchRecordDetailUseCase: fetchRecordDetailUseCase
+                )
+            )
         }
     }
     

--- a/Packages/Features/Sources/Features/Map/MapView.swift
+++ b/Packages/Features/Sources/Features/Map/MapView.swift
@@ -11,11 +11,17 @@ import Dependencies
 import DesignSystem
 
 public struct MapView: View {
-    @StateObject private var viewModel = MapViewModel()
+    @StateObject private var viewModel: MapViewModel
     @State private var moveToUserLocation = false
     @EnvironmentObject private var nav: NavigationViewModel
     
-    public init() {}
+    public init() {
+        @Dependency(\.fetchMyRecordsUseCase) var fetchMyRecordsUseCase
+        
+        _viewModel = StateObject(
+            wrappedValue: MapViewModel(fetchMyRecordsUseCase: fetchMyRecordsUseCase)
+        )
+    }
     
     public var body: some View {
         ZStack {

--- a/Packages/Features/Sources/Features/Map/MapViewModel.swift
+++ b/Packages/Features/Sources/Features/Map/MapViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreLocation
 import Domain
 import Combine
+import Dependencies
 
 @MainActor
 final class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
@@ -20,12 +21,15 @@ final class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate 
     
     private let locationManager = CLLocationManager()
     
+    private let fetchMyRecordsUseCase: FetchMyRecordsUseCase
+    
     // TODO: 향후 의존성 주입(DI) 컨테이너를 통해 UseCase를 주입
     // private let fetchUseCase: FetchNearbyMotesUseCase
     
     // MARK: - Initialization
     
-    override init() {
+    init(fetchMyRecordsUseCase: FetchMyRecordsUseCase) {
+        self.fetchMyRecordsUseCase = fetchMyRecordsUseCase
         super.init()
         locationManager.delegate = self
         locationManager.requestWhenInUseAuthorization()
@@ -37,18 +41,25 @@ final class MapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate 
     // 지도에 표시할 오브젝트 데이터를 가져옴
     
     func fetchMapObjects() {
-        // MockDataProvider에서 Mote 배열 받아오기
-        let mockMotes = MockDataProvider.mockObjects()
-        
-        // Mote를 ObjectSummary로 매핑
-        self.objectSummaries = mockMotes.map { mote in
-            ObjectSummary(
-                id: mote.id, // 또는 mote 자체의 id가 있다면 그것 사용
-                title: mote.title,
-                latitude: mote.latitude,
-                longitude: mote.longitude,
-                flowerImage: mote.flower.objetImage
-            )
+        Task {
+            do {
+                // ✅ UseCase를 통해 실제 기록 데이터를 가져옵니다.
+                let records = try await fetchMyRecordsUseCase()
+                
+                // ✅ 가져온 Record를 ObjectSummary로 매핑합니다.
+                self.objectSummaries = records.map { record in
+                    ObjectSummary(
+                        id: record.record.id,
+                        title: record.record.title ?? "제목 없음",
+                        latitude: record.record.coordinate.latitude,
+                        longitude: record.record.coordinate.longitude,
+                        // Marker 정보에서 이미지를 가져와야 할 수 있습니다.
+                        flowerImage: record.marker.imageName
+                    )
+                }
+            } catch {
+                print(" 지도 기록 가져오기 실패: \(error.localizedDescription)")
+            }
         }
     }
     

--- a/Packages/Features/Sources/Features/MyRecordBottomSheet/CustomModalView.swift
+++ b/Packages/Features/Sources/Features/MyRecordBottomSheet/CustomModalView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import MapKit
+import Dependencies
 import CoreLocation
 import DesignSystem
 
@@ -252,7 +253,16 @@ struct CustomModalView: View {
         }
         .ignoresSafeArea(.all)
         .sheet(item: $selectedRecordID) { identifiableID in
-            RecordDetailBottomSheet(viewModel: RecordDetailViewModel(id: identifiableID.id))
+            // @Dependency로 UseCase를 가져옵니다.
+            @Dependency(\.fetchRecordDetailUseCase) var fetchRecordDetailUseCase
+            
+            RecordDetailBottomSheet(
+                // 생성자에 id와 함께 useCase를 전달합니다.
+                viewModel: RecordDetailViewModel(
+                    id: identifiableID.id,
+                    fetchRecordDetailUseCase: fetchRecordDetailUseCase
+                )
+            )
         }
 
     }

--- a/Packages/Features/Sources/Features/MyRecordView/MyRecordView.swift
+++ b/Packages/Features/Sources/Features/MyRecordView/MyRecordView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Dependencies
 import DesignSystem
 
 struct MyRecordView: View {
@@ -49,7 +50,14 @@ struct MyRecordView: View {
             .padding(.horizontal, 20)
             .navigationBarHidden(true)
             .sheet(item: $selectedRecordID) { identifiableID in
-                RecordDetailBottomSheet(viewModel: RecordDetailViewModel(id: identifiableID.id))
+                @Dependency(\.fetchRecordDetailUseCase) var fetchRecordDetailUseCase
+                
+                RecordDetailBottomSheet(
+                    viewModel: RecordDetailViewModel(
+                        id: identifiableID.id,
+                        fetchRecordDetailUseCase: fetchRecordDetailUseCase
+                    )
+                )
             }
         }
     }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/ImageCarouselView.swift
@@ -163,9 +163,6 @@ struct AddPhotoButton: View {
     }
 }
 
-#Preview {
-    ImageCarouselView(viewModel: RecordDetailViewModel(), isExpanded: true, isEditing: true)
-}
 
 
 

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailBottomSheet.swift
@@ -252,8 +252,3 @@ public struct RecordDetailBottomSheet: View {
     }
 }
 
-// MARK: - Preview
-
-#Preview {
-    RecordDetailBottomSheet(viewModel: RecordDetailViewModel())
-}

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -83,10 +83,12 @@ public final class RecordDetailViewModel: ObservableObject {
             for photo in photos {
                 group.addTask {
                     // FileStoreManager를 거치지 않고 URL에서 직접 로드 시도
-                    guard let data = try? Data(contentsOf: photo.url) else {
+                    do {
+                        let (data, _) = try await URLSession.shared.data(from: photo.url)
+                        return UIImage(data: data)
+                    } catch {
                         return nil
                     }
-                    return UIImage(data: data)
                 }
             }
             
@@ -111,12 +113,23 @@ public final class RecordDetailViewModel: ObservableObject {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월 d일"
         
+        let locationString = entity.record.address.fullAddress
+        
+        let titleString: String
+        // entity.record.title이 nil이 아니면서, 공백을 제외한 실제 내용이 있을 경우
+        if let originalTitle = entity.record.title, !originalTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            titleString = originalTitle
+        } else {
+            // 그 외의 경우 (nil이거나 빈 문자열일 때) location을 사용
+            titleString = "\(locationString)에서"
+        }
+        
         return RecordDetailUIModel(
-            title: (entity.record.title ?? "").isEmpty ? "제목 없음" : entity.record.title!,
+            title: titleString,
             flowerName: entity.marker.displayName,
             flowerMeaning: entity.marker.floriography,
-            location: entity.record.address.fullAddress, // 실제 주소로 변경
-            date: dateFormatter.string(from: entity.record.date), // 실제 날짜로 변경
+            location: locationString,
+            date: dateFormatter.string(from: entity.record.date),
             images: images
         )
     }

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -24,6 +24,7 @@ public final class RecordDetailViewModel: ObservableObject {
     private var originalDetail: RecordDetailUIModel?
     // Combine 구독 관리를 위한 cancellables
     private var cancellables: Set<AnyCancellable> = []
+    private let fetchRecordDetailUseCase: FetchRecordDetailUseCase
 
     // MARK: - Computed Properties
     public var isSaveButtonDisabled: Bool {
@@ -75,13 +76,17 @@ public final class RecordDetailViewModel: ObservableObject {
 //        }
 //    }
     
-    public init(id: UUID) {
-        fetchRecordDetails(id: id)
+    public init(
+        id: UUID,
+        fetchRecordDetailUseCase: FetchRecordDetailUseCase
+    ) {
+        self.fetchRecordDetailUseCase = fetchRecordDetailUseCase
+        fetchRecordDetail(id: id)
     }
     
     // ARCamera 연동을 위한 추가 초기화
     public convenience init(arRecord: ARRecordModel) {
-        self.init()
+//        self.init()
 
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월 d일"
@@ -111,33 +116,83 @@ public final class RecordDetailViewModel: ObservableObject {
         self.originalDetail = detail
     }
     
-    /// id 기반으로 RecordDetailUIModel 생성 및 detail 세팅
-    func fetchRecordDetails(id: UUID) {
-        let motes = MockDataProvider.mockObjects()
+    
+    public func fetchRecordDetail(id: UUID) {
         
-        guard let mote = motes.first(where: { $0.id == id }) else {
-            print("❌ 해당 ID의 Mote를 찾을 수 없습니다.")
-            return
-        }
+        isLoading = true
 
+        Task {
+            do {
+                let entity = try await fetchRecordDetailUseCase(id: id)
+                let uiModel = mapToUIModel(entity: entity)
+                
+                await MainActor.run {
+                    self.detail = uiModel
+                    self.originalDetail = uiModel
+                    self.isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.isLoading = false
+                    print("RecordDetailViewModel fetch error: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+    
+    private func mapToUIModel(entity: RecordDetail) -> RecordDetailUIModel {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월 d일"
 
-        let images: [UIImage] = mote.images.compactMap {
-            UIImage(named: $0) ?? UIImage(systemName: "photo")
+        // 이미지 URL을 UIImage로 변환 (비동기 로딩 대신 placeholder 사용 가능)
+        // 여기서는 단순히 UIImage(systemName:)으로 더미 이미지 처리
+        let images: [UIImage] = entity.record.photos.compactMap { photo in
+            if let url = URL(string: photo.url.absoluteString),
+               let data = try? Data(contentsOf: url),
+               let image = UIImage(data: data) {
+                return image
+            } else {
+                return UIImage(systemName: "photo") // 로딩 실패 시 기본 이미지
+            }
         }
 
-        self.detail = RecordDetailUIModel(
-            title: mote.title,
-            flowerName: mote.flower.name,
-            flowerMeaning: mote.flower.floriography,
-            location: mote.address,
-            date: dateFormatter.string(from: mote.createdAt),
+        return RecordDetailUIModel(
+            title: entity.record.title ?? "",
+            flowerName: entity.marker.displayName,
+            flowerMeaning: entity.marker.floriography,
+            location: entity.record.address.fullAddress, // 주소 매핑
+            date: dateFormatter.string(from: entity.record.date),
             images: images
         )
-        
-        self.originalDetail = self.detail
     }
+
+    /// id 기반으로 RecordDetailUIModel 생성 및 detail 세팅
+//    func fetchRecordDetails(id: UUID) {
+//        let motes = MockDataProvider.mockObjects()
+//        
+//        guard let mote = motes.first(where: { $0.id == id }) else {
+//            print("❌ 해당 ID의 Mote를 찾을 수 없습니다.")
+//            return
+//        }
+//
+//        let dateFormatter = DateFormatter()
+//        dateFormatter.dateFormat = "yyyy년 M월 d일"
+//
+//        let images: [UIImage] = mote.images.compactMap {
+//            UIImage(named: $0) ?? UIImage(systemName: "photo")
+//        }
+//
+//        self.detail = RecordDetailUIModel(
+//            title: mote.title,
+//            flowerName: mote.flower.name,
+//            flowerMeaning: mote.flower.floriography,
+//            location: mote.address,
+//            date: dateFormatter.string(from: mote.createdAt),
+//            images: images
+//        )
+//        
+//        self.originalDetail = self.detail
+//    }
 
     // MARK: - User Actions
 

--- a/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
+++ b/Packages/Features/Sources/Features/Record/RecordDetail/RecordDetailViewModel.swift
@@ -14,100 +14,91 @@ struct RecordDetailUIModel {
 
 @MainActor
 public final class RecordDetailViewModel: ObservableObject {
-
+    
     // MARK: - Published Properties
     @Published var detail: RecordDetailUIModel?
     @Published var isEditing: Bool = false
     @Published var isLoading: Bool = false
-
+    
     // 수정 전 원본 데이터를 저장할 프로퍼티
     private var originalDetail: RecordDetailUIModel?
     // Combine 구독 관리를 위한 cancellables
     private var cancellables: Set<AnyCancellable> = []
     private let fetchRecordDetailUseCase: FetchRecordDetailUseCase
-
+    
     // MARK: - Computed Properties
     public var isSaveButtonDisabled: Bool {
         // 수정 모드가 아닐 때는 항상 비활성화
         guard isEditing else { return true }
-
+        
         // detail이 존재하고 이미지가 하나 이상 있어야 저장 버튼 활성화
         guard let detail = detail else { return true }
-
+        
         return detail.images.isEmpty
     }
-
+    
     
     // MARK: - Initialization
     
-    public init() {
-        // 기본 초기화 - 추후 필요시 기본 동작 추가
-    }
-    
-//    public convenience init(record: Record) {
-//        self.init() // 기존 init 호출
-//        
-//        // Task를 이용해 파일 경로로부터 이미지를 비동기적으로 불러옵니다.
-//        Task {
-//            var loadedImages: [UIImage] = []
-//            for fileName in record.imageFileNames {
-//                if let image = await FileStoreManager.shared.loadImage(fileName: fileName) {
-//                    loadedImages.append(image)
-//                }
-//            }
-//            
-//            let dateFormatter = DateFormatter()
-//            dateFormatter.dateFormat = "yyyy년 M월 d일"
-//
-//            // 불러온 이미지와 Record의 정보로 UI 모델을 생성합니다.
-//            let detailModel = RecordDetailUIModel(
-//                title: record.flower.name, // 제목은 우선 꽃 이름으로 설정
-//                flowerName: record.flower.name,
-//                flowerMeaning: record.flower.meaning,
-//                location: "위치 정보 미정", // 위치 정보는 추후 추가
-//                date: dateFormatter.string(from: Date()),
-//                images: loadedImages
-//            )
-//
-//            // @Published 프로퍼티를 업데이트하여 View에 반영합니다.
-//            self.detail = detailModel
-//            // 수정 기능을 위해 원본도 함께 저장해 둡니다.
-//            self.originalDetail = detailModel
-//        }
-//    }
-    
-    public init(
-        id: UUID,
-        fetchRecordDetailUseCase: FetchRecordDetailUseCase
-    ) {
+    public init(id: UUID, fetchRecordDetailUseCase: FetchRecordDetailUseCase) {
         self.fetchRecordDetailUseCase = fetchRecordDetailUseCase
-        fetchRecordDetail(id: id)
+        
+        // 생성과 동시에 데이터 로딩 시작
+        Task {
+            await fetchFullRecordDetail(id: id)
+        }
     }
     
-    // ARCamera 연동을 위한 추가 초기화
-    public convenience init(arRecord: ARRecordModel) {
-//        self.init()
-
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy년 M월 d일"
-
-        // 기존 fetchRecordDetails와 동일한 방식으로 Mock 이미지 생성
-        let dummyPhotos = ["photo.artframe", "camera.fill", "tree.fill"]
-        let images = dummyPhotos.compactMap { UIImage(systemName: $0) }
-
-        // ARRecordModel의 데이터를 RecordDetailUIModel로 변환
-        let mockDetail = RecordDetailUIModel(
-            title: arRecord.title.isEmpty ? "제목 없음" : arRecord.title,
-            flowerName: "프리지아",  // TODO: MarkerType에서 꽃 이름 가져오기
-            flowerMeaning: "영원한 사랑",  // TODO: MarkerType에서 꽃말 가져오기
-            location: "포항공과대학교",  // TODO: 실제 주소 정보 사용
-            date: dateFormatter.string(from: arRecord.createdDate),
-            images: images
-        )
-
-        self.setDetail(mockDetail)
+    private func fetchFullRecordDetail(id: UUID) async {
+        self.isLoading = true
+        
+        do {
+            // 1. UseCase를 통해 기록의 기본 정보를 가져옵니다.
+            let domainDetail = try await fetchRecordDetailUseCase(id: id)
+            
+            // 2. 파일 이름 목록으로 실제 이미지를 비동기 로드합니다.
+            let images = await loadImages(from: domainDetail.record.photos)
+            
+            // 3. 모든 데이터를 사용해 최종 UI 모델을 만듭니다.
+            let uiModel = mapToUIModel(entity: domainDetail, images: images)
+            
+            // 4. Main 쓰레드에서 UI 상태를 업데이트합니다.
+            self.detail = uiModel
+            self.originalDetail = uiModel
+            
+        } catch {
+            print("RecordDetailViewModel fetch error: \(error.localizedDescription)")
+            // TODO: 사용자에게 에러 알림 표시
+        }
+        
+        self.isLoading = false
     }
-  
+    
+    private func loadImages(from photos: [Photo]) async -> [UIImage] {
+        guard !photos.isEmpty else { return [] }
+        
+        return await withTaskGroup(of: UIImage?.self, body: { group in
+            var loadedImages: [UIImage] = []
+            
+            for photo in photos {
+                group.addTask {
+                    // FileStoreManager를 거치지 않고 URL에서 직접 로드 시도
+                    guard let data = try? Data(contentsOf: photo.url) else {
+                        return nil
+                    }
+                    return UIImage(data: data)
+                }
+            }
+            
+            for await image in group {
+                if let image = image {
+                    loadedImages.append(image)
+                }
+            }
+            return loadedImages
+        })
+    }
+    
     // MARK: - Methods
     
     // ARCamera에서 사용할 수 있도록 detail을 설정하는 메서드
@@ -116,103 +107,67 @@ public final class RecordDetailViewModel: ObservableObject {
         self.originalDetail = detail
     }
     
-    
-    public func fetchRecordDetail(id: UUID) {
-        
-        isLoading = true
-
-        Task {
-            do {
-                let entity = try await fetchRecordDetailUseCase(id: id)
-                let uiModel = mapToUIModel(entity: entity)
-                
-                await MainActor.run {
-                    self.detail = uiModel
-                    self.originalDetail = uiModel
-                    self.isLoading = false
-                }
-            } catch {
-                await MainActor.run {
-                    self.isLoading = false
-                    print("RecordDetailViewModel fetch error: \(error.localizedDescription)")
-                }
-            }
-        }
-    }
-    
-    private func mapToUIModel(entity: RecordDetail) -> RecordDetailUIModel {
+    private func mapToUIModel(entity: RecordDetail, images: [UIImage]) -> RecordDetailUIModel {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 M월 d일"
-
-        // 이미지 URL을 UIImage로 변환 (비동기 로딩 대신 placeholder 사용 가능)
-        // 여기서는 단순히 UIImage(systemName:)으로 더미 이미지 처리
-        let images: [UIImage] = entity.record.photos.compactMap { photo in
-            if let url = URL(string: photo.url.absoluteString),
-               let data = try? Data(contentsOf: url),
-               let image = UIImage(data: data) {
-                return image
-            } else {
-                return UIImage(systemName: "photo") // 로딩 실패 시 기본 이미지
-            }
-        }
-
+        
         return RecordDetailUIModel(
-            title: entity.record.title ?? "",
+            title: (entity.record.title ?? "").isEmpty ? "제목 없음" : entity.record.title!,
             flowerName: entity.marker.displayName,
             flowerMeaning: entity.marker.floriography,
-            location: entity.record.address.fullAddress, // 주소 매핑
-            date: dateFormatter.string(from: entity.record.date),
+            location: entity.record.address.fullAddress, // 실제 주소로 변경
+            date: dateFormatter.string(from: entity.record.date), // 실제 날짜로 변경
             images: images
         )
     }
-
+    
     /// id 기반으로 RecordDetailUIModel 생성 및 detail 세팅
-//    func fetchRecordDetails(id: UUID) {
-//        let motes = MockDataProvider.mockObjects()
-//        
-//        guard let mote = motes.first(where: { $0.id == id }) else {
-//            print("❌ 해당 ID의 Mote를 찾을 수 없습니다.")
-//            return
-//        }
-//
-//        let dateFormatter = DateFormatter()
-//        dateFormatter.dateFormat = "yyyy년 M월 d일"
-//
-//        let images: [UIImage] = mote.images.compactMap {
-//            UIImage(named: $0) ?? UIImage(systemName: "photo")
-//        }
-//
-//        self.detail = RecordDetailUIModel(
-//            title: mote.title,
-//            flowerName: mote.flower.name,
-//            flowerMeaning: mote.flower.floriography,
-//            location: mote.address,
-//            date: dateFormatter.string(from: mote.createdAt),
-//            images: images
-//        )
-//        
-//        self.originalDetail = self.detail
-//    }
-
+    //    func fetchRecordDetails(id: UUID) {
+    //        let motes = MockDataProvider.mockObjects()
+    //
+    //        guard let mote = motes.first(where: { $0.id == id }) else {
+    //            print("❌ 해당 ID의 Mote를 찾을 수 없습니다.")
+    //            return
+    //        }
+    //
+    //        let dateFormatter = DateFormatter()
+    //        dateFormatter.dateFormat = "yyyy년 M월 d일"
+    //
+    //        let images: [UIImage] = mote.images.compactMap {
+    //            UIImage(named: $0) ?? UIImage(systemName: "photo")
+    //        }
+    //
+    //        self.detail = RecordDetailUIModel(
+    //            title: mote.title,
+    //            flowerName: mote.flower.name,
+    //            flowerMeaning: mote.flower.floriography,
+    //            location: mote.address,
+    //            date: dateFormatter.string(from: mote.createdAt),
+    //            images: images
+    //        )
+    //
+    //        self.originalDetail = self.detail
+    //    }
+    
     // MARK: - User Actions
-
+    
     func editButtonTapped() {
         originalDetail = detail
         isEditing = true
     }
-
+    
     func saveButtonTapped() {
         if let detail = detail,
            detail.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             self.detail?.title = "\(detail.location)에서"
         }
-
+        
         // TODO: 변경된 detail 객체를 저장
         print("저장할 제목: \(detail?.title ?? "")")
         isEditing = false
     }
-
-
+    
+    
     func deleteButtonTapped() {
         print("삭제 버튼 탭됨")
     }
@@ -225,9 +180,9 @@ public final class RecordDetailViewModel: ObservableObject {
             }
             .store(in: &cancellables)
     }
-
+    
     // MARK: - Image Handling
-
+    
     func addImages(from assets: [PHAsset], using albumViewModel: CustomAlbumViewModel) {
         guard detail != nil else { return }
         
@@ -250,15 +205,9 @@ public final class RecordDetailViewModel: ObservableObject {
             isLoading = false
         }
     }
-
+    
     func deleteImage(_ image: UIImage) {
         detail?.images.removeAll { $0 == image }
     }
 }
 
-extension RecordDetailViewModel {
-    public convenience init(summary: ObjectSummary) {
-        self.init()
-        // TODO: summary 객체로부터 실제 데이터를 받아와 프로퍼티를 채우는 로직 구현
-    }
-}

--- a/Packages/Features/Sources/Features/RecordSave/FileStoreManager.swift
+++ b/Packages/Features/Sources/Features/RecordSave/FileStoreManager.swift
@@ -33,7 +33,7 @@ public actor FileStoreManager {
         return imagesPath
     }
     
-    func saveImage(_ image: UIImage) -> String? {
+    func saveImage(_ image: UIImage) -> URL? {
         guard let directory = imagesDirectory else { return nil }
         
         let fileName = "\(UUID().uuidString).jpeg"
@@ -46,8 +46,8 @@ public actor FileStoreManager {
         
         do {
             try data.write(to: fileURL)
-            print("✅ 이미지 저장 성공: \(fileName)")
-            return fileName
+            print("✅ 이미지 저장 성공: \(fileURL.path)")
+            return fileURL
         } catch {
             print("Error: 이미지 파일 쓰기 실패 - \(error.localizedDescription)")
             return nil

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -90,7 +90,8 @@ public final class RecordSaveSheetViewModel: ObservableObject {
             }
             
             let payload = FinalRecordPayload(
-                imageURLs: savedFileURLs, 
+                imageURLs: savedFileURLs,
+                address: self.address,
                 description: ""
             )
             

--- a/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
+++ b/Packages/Features/Sources/Features/RecordSave/RecordSaveSheetViewModel.swift
@@ -81,16 +81,16 @@ public final class RecordSaveSheetViewModel: ObservableObject {
         isLoading = true
         Task {
             let images = self.selectedImages
-            var savedFileNames: [String] = []
+            var savedFileURLs: [URL] = []
             
             for image in images {
-                if let fileName = await FileStoreManager.shared.saveImage(image) {
-                    savedFileNames.append(fileName)
+                if let fileURL = await FileStoreManager.shared.saveImage(image) {
+                    savedFileURLs.append(fileURL)
                 }
             }
             
             let payload = FinalRecordPayload(
-                imageFileNames: savedFileNames,
+                imageURLs: savedFileURLs, 
                 description: ""
             )
             

--- a/Packages/Features/Sources/Features/Shared/FinalRecordPayload.swift
+++ b/Packages/Features/Sources/Features/Shared/FinalRecordPayload.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 public struct FinalRecordPayload {
-    let imageFileNames: [String]
+    let imageURLs: [URL]
     let description: String
 }

--- a/Packages/Features/Sources/Features/Shared/FinalRecordPayload.swift
+++ b/Packages/Features/Sources/Features/Shared/FinalRecordPayload.swift
@@ -2,6 +2,6 @@ import Foundation
 
 public struct FinalRecordPayload {
     let imageURLs: [URL]
-    let address : String
+    let address: String
     let description: String
 }

--- a/Packages/Features/Sources/Features/Shared/FinalRecordPayload.swift
+++ b/Packages/Features/Sources/Features/Shared/FinalRecordPayload.swift
@@ -2,5 +2,6 @@ import Foundation
 
 public struct FinalRecordPayload {
     let imageURLs: [URL]
+    let address : String
     let description: String
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #164 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

1. 주소 데이터 추가
  - FinalRecordPayload에 address 필드 추가
  - ARCameraViewModel.requestSave()에서 fetchAddress() 호출하여 주소 문자열 획득
  - RecordSaveSheet로 전달해 저장 화면에 표시
  - RecordSaveSheetViewModel이 주소 데이터를 포함해 최종 데이터 저장
2. 이미지 로딩 연동
  - RecordDetailBottomSheet에서 저장된 기록 이미지 정상 로딩되도록 데이터 플로우 개선
 3. ARCameraView → MapView 데이터 연동
  - 기록 저장 완료 시 MapViewModel에 데이터 전달
  - MapView에 마커(annotation)로 기록 표시
  - 저장 후 지도 화면에서 즉시 반영되도록 흐름 개선

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 기록 생성 후 MapView에 마커 정상 표시 여부 확인
- [x] 저장된 기록 이미지가 RecordDetailBottomSheet에서 정상적으로 불러와지는지 테스트
- [x] 주소 데이터가 저장 화면과 최종 데이터에 올바르게 반영되는지 검증
---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
